### PR TITLE
docs: Document vision for agentic and zero-configuration Tako

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,4 +184,5 @@ Tako differentiates itself from existing tools by focusing on **dependency-aware
 *   A plugin system for custom command types and integrations.
 *   Support for using local copies of dependent repositories.
 *   **Asynchronous, Observable Workflows:** A "remote mode" where Tako can execute long-running, asynchronous workflows in a cloud environment. This would transform Tako into a powerful automation platform with features like human-in-the-loop approvals and a centralized web UI for observing progress. See issue #47 for the detailed vision.
+*   **Agentic, Zero-Configuration Workflows:** An "agentic mode" where Tako can infer workflows and dependency graphs directly from the source code and its environment, reducing the need for manual configuration. See issue #50 for the detailed vision.
 *   A more advanced filtering syntax might be needed in the future to support ignoring a single repo without ignoring its downstream dependencies. For example, a flag like `--ignore-single <repo>` could be introduced.


### PR DESCRIPTION
This commit updates the `README.md` to include the long-term vision for an agentic, zero-configuration Tako.

This ensures that future design discussions and contributions are aligned with this strategic direction.

Fixes: #51