### PR TITLE
fix(version): add newline to error output

### DIFF
--- a/cmd/tako/internal/version.go
+++ b/cmd/tako/internal/version.go
@@ -23,7 +23,7 @@ var versionCmd = &cobra.Command{
 
 func Version(_ *cobra.Command, _ []string) {
 	if version, err := deriveVersion(); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%q", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%q\n", err)
 	} else {
 		fmt.Println(version)
 	}


### PR DESCRIPTION
This commit adds a newline character to the error message printed by the `version` command. This improves the readability of the error output in the terminal.

Fixes: #45