### PR TITLE
feat(config): add basic configuration validation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - containedctx
+    - contextcheck
+    - fatcontext
+    - godot
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unparam
+    - unused
+    - usetesting
+    

--- a/all_test.go
+++ b/all_test.go
@@ -33,6 +33,14 @@ func TestGovulncheck(t *testing.T) {
 	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@latest", "./...")
 }
 
+func TestGodocLint(t *testing.T) {
+	rungo(t, "run", "github.com/godoc-lint/godoc-lint/cmd/godoclint@latest", "./...")
+}
+
+func TestCoverage(t *testing.T) {
+	rungo(t, "test", "-coverprofile=coverage.out", "./internal/...", "./cmd/...")
+}
+
 func rungo(t *testing.T, args ...string) {
 	t.Helper()
 

--- a/cmd/tako/internal/validate.go
+++ b/cmd/tako/internal/validate.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/dangazineu/tako/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [file]",
+	Short: "Validate a tako.yml file",
+	Long:  `Validate a tako.yml file.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, err := config.Load(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Println("Validation successful!")
+		return nil
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/dangazineu/tako
 
 go 1.24.4
 
-require github.com/spf13/cobra v1.9.1
+require (
+	github.com/spf13/cobra v1.9.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type TakoConfig struct {
+	Version    string      `yaml:"version"`
+	Metadata   Metadata    `yaml:"metadata"`
+	Artifacts  []Artifact  `yaml:"artifacts"`
+	Dependents []Dependent `yaml:"dependents"`
+	Workflows  []Workflow  `yaml:"workflows"`
+}
+
+type Metadata struct {
+	Name string `yaml:"name"`
+}
+
+type Artifact struct {
+	Name           string `yaml:"name"`
+	Description    string `yaml:"description"`
+	Image          string `yaml:"image"`
+	Command        string `yaml:"command"`
+	Path           string `yaml:"path"`
+	InstallCommand string `yaml:"install_command"`
+	VerifyCommand  string `yaml:"verify_command"`
+}
+
+type Dependent struct {
+	Repo      string   `yaml:"repo"`
+	Artifacts []string `yaml:"artifacts"`
+	Workflows []string `yaml:"workflows"`
+}
+
+type Workflow struct {
+	Name      string    `yaml:"name"`
+	Image     string    `yaml:"image"`
+	Env       []string  `yaml:"env"`
+	Resources Resources `yaml:"resources"`
+	Steps     []string  `yaml:"steps"`
+}
+
+type Resources struct {
+	CPU    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}
+
+func Load(path string) (*TakoConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read config file: %w", err)
+	}
+
+	var config TakoConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("could not unmarshal config: %w", err)
+	}
+
+	if config.Version == "" {
+		return nil, fmt.Errorf("missing required field: version")
+	}
+
+	if config.Dependents == nil {
+		return nil, fmt.Errorf("missing required field: dependents")
+	}
+
+	return &config, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func buildYAML(version *string, dependents []string) string {
+	var sb strings.Builder
+	if version != nil {
+		sb.WriteString(fmt.Sprintf("version: %q\n", *version))
+	}
+	if dependents != nil {
+		sb.WriteString("dependents:\n")
+		for _, d := range dependents {
+			sb.WriteString(fmt.Sprintf("  - repo: %q\n", d))
+		}
+	}
+	return sb.String()
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestLoad(t *testing.T) {
+	testCases := []struct {
+		name        string
+		version     *string
+		dependents  []string
+		extra       string
+		expectError bool
+	}{
+		{
+			name:        "valid config",
+			version:     stringPtr("1.2"),
+			dependents:  []string{"my-org/client-a:main"},
+			expectError: false,
+		},
+		{
+			name:        "missing version",
+			version:     nil,
+			dependents:  []string{"my-org/client-a:main"},
+			expectError: true,
+		},
+		{
+			name:        "missing dependents",
+			version:     stringPtr("1.2"),
+			dependents:  nil,
+			expectError: true,
+		},
+		{
+			name:        "invalid yaml",
+			version:     stringPtr("1.2"),
+			dependents:  []string{"my-org/client-a:main"},
+			extra:       "  - invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpfile, err := os.CreateTemp(t.TempDir(), "tako.yml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			content := buildYAML(tc.version, tc.dependents) + tc.extra
+			if _, err := tmpfile.Write([]byte(content)); err != nil {
+				t.Fatal(err)
+			}
+			if err := tmpfile.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = Load(tmpfile.Name())
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces a `config` package and a `validate` command to perform basic validation of `tako.yml` files.

The `config.Load` function now checks for the presence of the required `version` and `dependents` fields. The new `tako validate` command allows users to easily check their configuration files for these basic requirements.

This change also includes unit tests for the `config` package, with 90.9% test coverage.

Fixes: #14