### PR TITLE
fix(e2e): ensure local and remote tests run against the same configuration

### DIFF
--- a/cmd/tako/internal/graph_test.go
+++ b/cmd/tako/internal/graph_test.go
@@ -14,7 +14,9 @@ func TestGraphCmd(t *testing.T) {
 
 	// Create a mock repository
 	repoA := filepath.Join(tmpDir, "repo-a")
-	os.Mkdir(repoA, 0755)
+	if err := os.Mkdir(repoA, 0755); err != nil {
+		t.Fatalf("failed to create repoA: %v", err)
+	}
 	takoA := `
 version: 0.1.0
 metadata:

--- a/cmd/takotest/internal/cleanup.go
+++ b/cmd/takotest/internal/cleanup.go
@@ -12,8 +12,9 @@ func NewCleanupCmd() *cobra.Command {
 		Short: "Cleanup a test case",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			owner, _ := cmd.Flags().GetString("owner")
 			testCaseName := args[0]
-			testCase, ok := e2e.TestCases[testCaseName]
+			testCase, ok := e2e.GetTestCases(owner)[testCaseName]
 			if !ok {
 				return fmt.Errorf("test case not found: %s", testCaseName)
 			}
@@ -27,5 +28,7 @@ func NewCleanupCmd() *cobra.Command {
 			return testCase.Cleanup(client)
 		},
 	}
+	cmd.Flags().String("owner", "", "The owner of the repositories")
+	cmd.MarkFlagRequired("owner")
 	return cmd
 }

--- a/cmd/takotest/internal/setup.go
+++ b/cmd/takotest/internal/setup.go
@@ -13,8 +13,9 @@ func NewSetupCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			local, _ := cmd.Flags().GetBool("local")
+			owner, _ := cmd.Flags().GetString("owner")
 			testCaseName := args[0]
-			testCase, ok := e2e.TestCases[testCaseName]
+			testCase, ok := e2e.GetTestCases(owner)[testCaseName]
 			if !ok {
 				return fmt.Errorf("test case not found: %s", testCaseName)
 			}
@@ -39,5 +40,7 @@ func NewSetupCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool("local", false, "Setup the test case locally")
+	cmd.Flags().String("owner", "", "The owner of the repositories")
+	cmd.MarkFlagRequired("owner")
 	return cmd
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -38,7 +38,7 @@ func TestE2E(t *testing.T) {
 	if !*local && !*remote {
 		t.Fatal("either -local or -remote must be set")
 	}
-	for name, tc := range e2e.TestCases {
+	for name, tc := range e2e.GetTestCases(e2e.Org) {
 		tc := tc // capture range variable
 		t.Run(name, func(t *testing.T) {
 			if *local {
@@ -115,7 +115,7 @@ func runTest(t *testing.T, tc *e2e.TestCase, mode string) {
 	var rootPath string
 	if mode == "local" {
 		// For local mode, testCaseDir is the root, and we point to the first repo inside it
-		rootPath = filepath.Join(testCaseDir, e2e.Org, tc.Repositories[0].Name)
+		rootPath = filepath.Join(testCaseDir, tc.Repositories[0].Owner, tc.Repositories[0].Name)
 	} else {
 		// For remote mode, testCaseDir is the cloned repository root
 		rootPath = testCaseDir

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -114,8 +114,8 @@ func runTest(t *testing.T, tc *e2e.TestCase, mode string) {
 	var out bytes.Buffer
 	var rootPath string
 	if mode == "local" {
-		// For local mode, testCaseDir contains subdirectories for each repo
-		rootPath = filepath.Join(testCaseDir, tc.Repositories[0].Name)
+		// For local mode, testCaseDir is the root, and we point to the first repo inside it
+		rootPath = filepath.Join(testCaseDir, e2e.Org, tc.Repositories[0].Name)
 	} else {
 		// For remote mode, testCaseDir is the cloned repository root
 		rootPath = testCaseDir
@@ -124,7 +124,11 @@ func runTest(t *testing.T, tc *e2e.TestCase, mode string) {
 	t.Cleanup(func() {
 		os.RemoveAll(cacheDir)
 	})
-	takoCmd := exec.Command(takoPath, "graph", "--root", rootPath, "--cache-dir", cacheDir)
+	args := []string{"graph", "--root", rootPath, "--cache-dir", cacheDir}
+	if mode == "local" {
+		args = append(args, "--local")
+	}
+	takoCmd := exec.Command(takoPath, args...)
 	takoCmd.Stdout = &out
 	takoCmd.Stderr = &out
 	err = takoCmd.Run()
@@ -145,6 +149,18 @@ func runTest(t *testing.T, tc *e2e.TestCase, mode string) {
 
 func getExpectedOutput(testCaseName string) string {
 	switch testCaseName {
+	case "simple-graph":
+		return `repo-a
+└── repo-b
+`
+	case "complex-graph":
+		return `repo-a
+├── repo-b
+│   └── repo-c
+│       └── repo-e
+└── repo-d
+    └── repo-e
+`
 	case "deep-graph":
 		return `repo-x
 └── repo-y

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -45,9 +45,15 @@ func TestBuildGraph(t *testing.T) {
 		repoB := filepath.Join(tmpDir, "repo-b")
 		repoC := filepath.Join(tmpDir, "repo-c")
 
-		os.Mkdir(repoA, 0755)
-		os.Mkdir(repoB, 0755)
-		os.Mkdir(repoC, 0755)
+		if err := os.Mkdir(repoA, 0755); err != nil {
+			t.Fatalf("failed to create repoA: %v", err)
+		}
+		if err := os.Mkdir(repoB, 0755); err != nil {
+			t.Fatalf("failed to create repoB: %v", err)
+		}
+		if err := os.Mkdir(repoC, 0755); err != nil {
+			t.Fatalf("failed to create repoC: %v", err)
+		}
 
 		// Create mock tako.yml files
 		takoA := `
@@ -117,8 +123,12 @@ dependents: []
 		repoA := filepath.Join(tmpDir, "repo-a")
 		repoB := filepath.Join(tmpDir, "repo-b")
 
-		os.Mkdir(repoA, 0755)
-		os.Mkdir(repoB, 0755)
+		if err := os.Mkdir(repoA, 0755); err != nil {
+			t.Fatalf("failed to create repoA: %v", err)
+		}
+		if err := os.Mkdir(repoB, 0755); err != nil {
+			t.Fatalf("failed to create repoB: %v", err)
+		}
 
 		// Init git repo in repoB
 		cmd := exec.Command("git", "init")
@@ -176,8 +186,12 @@ dependents: []
 		repoA := filepath.Join(tmpDir, "repo-a")
 		repoB := filepath.Join(tmpDir, "repo-b")
 
-		os.Mkdir(repoA, 0755)
-		os.Mkdir(repoB, 0755)
+		if err := os.Mkdir(repoA, 0755); err != nil {
+			t.Fatalf("failed to create repoA: %v", err)
+		}
+		if err := os.Mkdir(repoB, 0755); err != nil {
+			t.Fatalf("failed to create repoB: %v", err)
+		}
 
 		// Init git repo in repoB
 		cmd := exec.Command("git", "init")

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -1,0 +1,5 @@
+package e2e
+
+const (
+	Org = "tako-test"
+)

--- a/test/e2e/testcase.go
+++ b/test/e2e/testcase.go
@@ -12,9 +12,6 @@ import (
 	"github.com/google/go-github/v63/github"
 )
 
-const (
-	Org = "tako-test"
-)
 
 type TestCase struct {
 	Name         string
@@ -22,207 +19,228 @@ type TestCase struct {
 }
 
 type Repository struct {
+	Owner      string
 	Name       string
 	TakoConfig *config.TakoConfig
 	CloneURL   string
 }
 
-var TestCases = map[string]TestCase{
-	"simple-graph": {
-		Name: "simple-graph",
-		Repositories: []Repository{
-			{
-				Name: "repo-a",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-a",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-b:main"},
-					},
-				},
-			},
-			{
-				Name: "repo-b",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-b",
-					},
-					Dependents: []config.Dependent{},
-				},
-			},
-		},
-	},
-	"complex-graph": {
-		Name: "complex-graph",
-		Repositories: []Repository{
-			{
-				Name: "repo-a",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-a",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-b:main"},
-						{Repo: "tako-test/repo-d:main"},
+func GetTestCases(owner string) map[string]TestCase {
+	return map[string]TestCase{
+		"simple-graph": {
+			Name: "simple-graph",
+			Repositories: []Repository{
+				{
+					Owner: owner,
+					Name:  "repo-a",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-a",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-b:main", owner)},
+						},
 					},
 				},
-			},
-			{
-				Name: "repo-b",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-b",
+				{
+					Owner: owner,
+					Name:  "repo-b",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-b",
+						},
+						Dependents: []config.Dependent{},
 					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-c:main"},
-					},
-				},
-			},
-			{
-				Name: "repo-c",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-c",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-e:main"},
-					},
-				},
-			},
-			{
-				Name: "repo-d",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-d",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-e:main"},
-					},
-				},
-			},
-			{
-				Name: "repo-e",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-e",
-					},
-					Dependents: []config.Dependent{},
 				},
 			},
 		},
-	},
-	"deep-graph": {
-		Name: "deep-graph",
-		Repositories: []Repository{
-			{
-				Name: "repo-x",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-x",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-y:main"},
-					},
-				},
-			},
-			{
-				Name: "repo-y",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-y",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-z:main"},
+		"complex-graph": {
+			Name: "complex-graph",
+			Repositories: []Repository{
+				{
+					Owner: owner,
+					Name:  "repo-a",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-a",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-b:main", owner)},
+							{Repo: fmt.Sprintf("%s/repo-d:main", owner)},
+						},
 					},
 				},
-			},
-			{
-				Name: "repo-z",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-z",
-					},
-					Dependents: []config.Dependent{},
-				},
-			},
-		},
-	},
-	"diamond-dependency-graph": {
-		Name: "diamond-dependency-graph",
-		Repositories: []Repository{
-			{
-				Name: "repo-a",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-a",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-b:main"},
-						{Repo: "tako-test/repo-d:main"},
+				{
+					Owner: owner,
+					Name:  "repo-b",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-b",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-c:main", owner)},
+						},
 					},
 				},
-			},
-			{
-				Name: "repo-b",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-b",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-c:main"},
-					},
-				},
-			},
-			{
-				Name: "repo-c",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-c",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-e:main"},
+				{
+					Owner: owner,
+					Name:  "repo-c",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-c",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-e:main", owner)},
+						},
 					},
 				},
-			},
-			{
-				Name: "repo-d",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-d",
-					},
-					Dependents: []config.Dependent{
-						{Repo: "tako-test/repo-e:main"},
+				{
+					Owner: owner,
+					Name:  "repo-d",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-d",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-e:main", owner)},
+						},
 					},
 				},
-			},
-			{
-				Name: "repo-e",
-				TakoConfig: &config.TakoConfig{
-					Version: "0.1.0",
-					Metadata: config.Metadata{
-						Name: "repo-e",
+				{
+					Owner: owner,
+					Name:  "repo-e",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-e",
+						},
+						Dependents: []config.Dependent{},
 					},
-					Dependents: []config.Dependent{},
 				},
 			},
 		},
-	},
+		"deep-graph": {
+			Name: "deep-graph",
+			Repositories: []Repository{
+				{
+					Owner: owner,
+					Name:  "repo-x",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-x",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-y:main", owner)},
+						},
+					},
+				},
+				{
+					Owner: owner,
+					Name:  "repo-y",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-y",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-z:main", owner)},
+						},
+					},
+				},
+				{
+					Owner: owner,
+					Name:  "repo-z",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-z",
+						},
+						Dependents: []config.Dependent{},
+					},
+				},
+			},
+		},
+		"diamond-dependency-graph": {
+			Name: "diamond-dependency-graph",
+			Repositories: []Repository{
+				{
+					Owner: owner,
+					Name:  "repo-a",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-a",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-b:main", owner)},
+							{Repo: fmt.Sprintf("%s/repo-d:main", owner)},
+						},
+					},
+				},
+				{
+					Owner: owner,
+					Name:  "repo-b",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-b",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-c:main", owner)},
+						},
+					},
+				},
+				{
+					Owner: owner,
+					Name:  "repo-c",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-c",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-e:main", owner)},
+						},
+					},
+				},
+				{
+					Owner: owner,
+					Name:  "repo-d",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-d",
+						},
+						Dependents: []config.Dependent{
+							{Repo: fmt.Sprintf("%s/repo-e:main", owner)},
+						},
+					},
+				},
+				{
+					Owner: owner,
+					Name:  "repo-e",
+					TakoConfig: &config.TakoConfig{
+						Version: "0.1.0",
+						Metadata: config.Metadata{
+							Name: "repo-e",
+						},
+						Dependents: []config.Dependent{},
+					},
+				},
+			},
+		},
+	}
 }
+
+var TestCases = GetTestCases(Org)
+
 
 func GetClient() (*github.Client, error) {
 	token := os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
@@ -237,15 +255,15 @@ func (tc *TestCase) Setup(client *github.Client) error {
 		repo := &tc.Repositories[i]
 
 		// Check if the repo exists, and if so, delete it
-		_, _, err := client.Repositories.Get(context.Background(), Org, repo.Name)
+		_, _, err := client.Repositories.Get(context.Background(), repo.Owner, repo.Name)
 		if err == nil {
-			_, err = client.Repositories.Delete(context.Background(), Org, repo.Name)
+			_, err = client.Repositories.Delete(context.Background(), repo.Owner, repo.Name)
 			if err != nil {
 				return err
 			}
 		}
 
-		createdRepo, _, err := client.Repositories.Create(context.Background(), Org, &github.Repository{
+		createdRepo, _, err := client.Repositories.Create(context.Background(), repo.Owner, &github.Repository{
 			Name: &repo.Name,
 		})
 		if err != nil {
@@ -258,7 +276,7 @@ func (tc *TestCase) Setup(client *github.Client) error {
 			return err
 		}
 
-		_, _, err = client.Repositories.CreateFile(context.Background(), Org, repo.Name, "tako.yml", &github.RepositoryContentFileOptions{
+		_, _, err = client.Repositories.CreateFile(context.Background(), repo.Owner, repo.Name, "tako.yml", &github.RepositoryContentFileOptions{
 			Message: github.String("initial commit"),
 			Content: content,
 			Branch:  github.String("main"),
@@ -278,7 +296,7 @@ func (tc *TestCase) SetupLocal() (string, error) {
 	}
 
 	for _, repo := range tc.Repositories {
-		repoPath := filepath.Join(tmpDir, Org, repo.Name)
+		repoPath := filepath.Join(tmpDir, repo.Owner, repo.Name)
 		if err := os.MkdirAll(repoPath, 0755); err != nil {
 			return "", err
 		}
@@ -302,7 +320,7 @@ func (tc *TestCase) SetupLocal() (string, error) {
 
 func (tc *TestCase) Cleanup(client *github.Client) error {
 	for _, repo := range tc.Repositories {
-		_, err := client.Repositories.Delete(context.Background(), Org, repo.Name)
+		_, err := client.Repositories.Delete(context.Background(), repo.Owner, repo.Name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change addresses issue #60.

### Description

The E2E test suite was modifying the `tako.yml` configuration files at test setup time, causing the local and remote test modes to run against different underlying configurations. This undermined the reliability of the tests as they were not validating the same logic in both environments.

This change removes all path-rewriting logic from `test/e2e/testcase.go` and standardizes all `tako.yml` definitions in the test cases to use the canonical `owner/repo` format.

The `SetupLocal` function has been updated to create a nested directory structure that mirrors the `owner/repo` path, and the core graph-building logic in the `graph` package can now correctly resolve dependencies when given a local root path that contains this `owner/repo` structure.

This change also makes the test cases more robust by parameterizing the owner of the repositories.

The `test/e2e/testcase.go` file has been updated to use a placeholder for the owner in the `tako.yml` configurations for the test cases. The `Setup` and `SetupLocal` functions have been updated to handle this parameterization.

The `cmd/takotest/main.go` file has been updated to add a new `--owner` flag to the `setup` and `cleanup` commands. The `setup` and `cleanup` commands' logic has been updated to use the value of the `--owner` flag when creating the test repositories.

### How to Test

Run the E2E tests in both local and remote mode:

```bash
go test -v -tags=e2e --local ./...
go test -v -tags=e2e --remote ./...
```

Fixes: #60