### PR TITLE
feat(cache): Add cache management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Tako differentiates itself from existing tools by focusing on **dependency-aware
 ## 3. Command-Line Interface (CLI)
 
 *   **Syntax:** `tako <command> [options] [args]`
-*   **Core Commands:** `version`, `graph`, `run`, `exec`, `init`, `doctor`, `artifacts`, `deps`
+*   **Core Commands:** `version`, `graph`, `run`, `exec`, `init`, `doctor`, `artifacts`, `deps`, `cache`
+*   **`tako cache`:** A command to manage Tako's cache.
+    *   `tako cache clean`: Removes all cached repositories and artifacts from Tako's cache directory.
 *   **`tako doctor`:** A command to validate the workspace health, checking `tako.yml` syntax, dependency availability, and Docker connectivity.
 *   **Flags:** `--dry-run`, `--verbose`, `--debug`, `--only`, `--ignore`, `--serial`, `--continue-on-error`, `--summarize-errors`, `--preserve-tmp`.
 

--- a/cmd/tako/internal/cache.go
+++ b/cmd/tako/internal/cache.go
@@ -1,0 +1,56 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCacheCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage tako's cache",
+	}
+
+	cmd.AddCommand(newCacheCleanCmd())
+
+	return cmd
+}
+
+func newCacheCleanCmd() *cobra.Command {
+	var confirm bool
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Clear the cache directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cacheDir, err := cmd.Flags().GetString("cache-dir")
+			if err != nil {
+				return err
+			}
+
+			if cacheDir == "~/.tako/cache" {
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					return err
+				}
+				cacheDir = filepath.Join(homeDir, ".tako", "cache")
+			}
+
+			if !confirm {
+				cmd.OutOrStdout().Write([]byte("This will delete the cache directory at " + cacheDir + ". Use --confirm to proceed.\n"))
+				return nil
+			}
+
+			cmd.OutOrStdout().Write([]byte("Cleaning cache...\n"))
+			if err := os.RemoveAll(cacheDir); err != nil {
+				return err
+			}
+			cmd.OutOrStdout().Write([]byte("Cache cleaned successfully.\n"))
+
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm the cache cleaning")
+	return cmd
+}

--- a/cmd/tako/internal/cache_test.go
+++ b/cmd/tako/internal/cache_test.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCacheCleanCmd(t *testing.T) {
+	// Create a temporary cache directory for testing
+	tmpDir, err := ioutil.TempDir("", "tako-cache-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a dummy file in the cache
+	dummyFile := filepath.Join(tmpDir, "dummy.txt")
+	err = ioutil.WriteFile(dummyFile, []byte("test"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write dummy file: %v", err)
+	}
+
+	// Redirect stdout to a buffer to capture output
+	var stdout bytes.Buffer
+	rootCmd := NewRootCmd()
+	cacheCmd, _, err := rootCmd.Find([]string{"cache"})
+	if err != nil {
+		t.Fatalf("Failed to find cache command: %v", err)
+	}
+	cacheCmd.SetOut(&stdout)
+
+	// Execute the command
+	rootCmd.SetArgs([]string{"cache", "clean", "--cache-dir", tmpDir, "--confirm"})
+	err = rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command execution failed: %v", err)
+	}
+
+	// Assertions
+	if !strings.Contains(stdout.String(), "Cleaning cache...") {
+		t.Errorf("Expected output to contain 'Cleaning cache...', got %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Cache cleaned successfully.") {
+		t.Errorf("Expected output to contain 'Cache cleaned successfully.', got %s", stdout.String())
+	}
+	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
+		t.Errorf("Cache directory should be deleted, but it still exists.")
+	}
+}
+

--- a/cmd/tako/internal/root.go
+++ b/cmd/tako/internal/root.go
@@ -19,6 +19,7 @@ It allows you to run commands across your repositories in the correct order, ens
 
 	cmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", "~/.tako/cache", "The cache directory to use.")
 	cmd.AddCommand(NewGraphCmd())
+	cmd.AddCommand(NewCacheCmd())
 	cmd.AddCommand(validateCmd)
 	cmd.AddCommand(NewVersionCmd())
 


### PR DESCRIPTION
This change introduces a new `tako cache` command with a `clean` subcommand.
The `clean` subcommand allows users to clear Tako's cache directory, which is useful for debugging and freeing up disk space.

The command includes a `--confirm` flag to prevent accidental deletion of the cache.

Fixes #36