### PR TITLE
feat(completion): Add shell completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Tako differentiates itself from existing tools by focusing on **dependency-aware
 ## 3. Command-Line Interface (CLI)
 
 *   **Syntax:** `tako <command> [options] [args]`
-*   **Core Commands:** `version`, `graph`, `run`, `exec`, `init`, `doctor`, `artifacts`, `deps`, `cache`
+*   **Core Commands:** `version`, `graph`, `run`, `exec`, `init`, `doctor`, `artifacts`, `deps`, `cache`, `completion`
+*   **`tako completion`:** A command to generate shell completion scripts for different shells.
 *   **`tako cache`:** A command to manage Tako's cache.
     *   `tako cache clean`: Removes all cached repositories and artifacts from Tako's cache directory.
 *   **`tako doctor`:** A command to validate the workspace health, checking `tako.yml` syntax, dependency availability, and Docker connectivity.

--- a/cmd/tako/internal/completion.go
+++ b/cmd/tako/internal/completion.go
@@ -1,0 +1,68 @@
+package internal
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+
+Bash:
+
+  $ source <(tako completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ tako completion bash > /etc/bash_completion.d/tako
+  # macOS:
+  $ tako completion bash > /usr/local/etc/bash_completion.d/tako
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ tako completion zsh > "${fpath[1]}/_tako"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+  $ tako completion fish | source
+
+  # To load completions for each session, execute once:
+  $ tako completion fish > ~/.config/fish/completions/tako.fish
+
+PowerShell:
+
+  PS> tako completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> tako completion powershell > tako.ps1
+  # and source this file from your PowerShell profile.
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletion(cmd.OutOrStdout())
+			case "zsh":
+				return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/tako/internal/completion_test.go
+++ b/cmd/tako/internal/completion_test.go
@@ -1,0 +1,73 @@
+package internal
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompletionCmd(t *testing.T) {
+	rootCmd := NewRootCmd()
+	rootCmd.AddCommand(NewCompletionCmd())
+
+	testCases := []struct {
+		name      string
+		args      []string
+		expectErr bool
+	}{
+		{
+			name:      "bash completion",
+			args:      []string{"completion", "bash"},
+			expectErr: false,
+		},
+		{
+			name:      "zsh completion",
+			args:      []string{"completion", "zsh"},
+			expectErr: false,
+		},
+		{
+			name:      "fish completion",
+			args:      []string{"completion", "fish"},
+			expectErr: false,
+		},
+		{
+			name:      "powershell completion",
+			args:      []string{"completion", "powershell"},
+			expectErr: false,
+		},
+		{
+			name:      "invalid shell",
+			args:      []string{"completion", "invalid"},
+			expectErr: true,
+		},
+		{
+			name:      "no shell",
+			args:      []string{"completion"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetErr(&out)
+			rootCmd.SetArgs(tc.args)
+
+			err := rootCmd.Execute()
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error, but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if !strings.Contains(out.String(), "comp") {
+					t.Errorf("Expected output to contain a completion script, but it did not")
+				}
+			}
+		})
+	}
+}

--- a/cmd/tako/internal/root.go
+++ b/cmd/tako/internal/root.go
@@ -20,6 +20,7 @@ It allows you to run commands across your repositories in the correct order, ens
 	cmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", "~/.tako/cache", "The cache directory to use.")
 	cmd.AddCommand(NewGraphCmd())
 	cmd.AddCommand(NewCacheCmd())
+	cmd.AddCommand(NewCompletionCmd())
 	cmd.AddCommand(validateCmd)
 	cmd.AddCommand(NewVersionCmd())
 


### PR DESCRIPTION
This change introduces a new `tako completion` command that generates shell completion scripts for Bash, Zsh, Fish, and PowerShell.

This command makes it easier for users to discover and use Tako's commands and flags.

Fixes #30