### PR TITLE
feat(graph): detect and report circular dependencies

### DIFF
--- a/cmd/tako/internal/cache_test.go
+++ b/cmd/tako/internal/cache_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,15 +10,11 @@ import (
 
 func TestCacheCleanCmd(t *testing.T) {
 	// Create a temporary cache directory for testing
-	tmpDir, err := ioutil.TempDir("", "tako-cache-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create a dummy file in the cache
 	dummyFile := filepath.Join(tmpDir, "dummy.txt")
-	err = ioutil.WriteFile(dummyFile, []byte("test"), 0644)
+	err := os.WriteFile(dummyFile, []byte("test"), 0644)
 	if err != nil {
 		t.Fatalf("Failed to write dummy file: %v", err)
 	}
@@ -51,4 +46,3 @@ func TestCacheCleanCmd(t *testing.T) {
 		t.Errorf("Cache directory should be deleted, but it still exists.")
 	}
 }
-

--- a/cmd/tako/internal/completion.go
+++ b/cmd/tako/internal/completion.go
@@ -49,7 +49,7 @@ PowerShell:
 `,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":

--- a/cmd/tako/internal/graph.go
+++ b/cmd/tako/internal/graph.go
@@ -23,6 +23,9 @@ func NewGraphCmd() *cobra.Command {
 			cacheDir, _ := cmd.Flags().GetString("cache-dir")
 			root, err := graph.BuildGraph(rootPath, cacheDir, localOnly)
 			if err != nil {
+				if _, ok := err.(*graph.CircularDependencyError); ok {
+					return err
+				}
 				return err
 			}
 			graph.PrintGraph(cmd.OutOrStdout(), root)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -140,6 +140,17 @@ func runTest(t *testing.T, tc *e2e.TestCase, mode string) {
 	takoCmd.Stdout = &out
 	takoCmd.Stderr = &out
 	err = takoCmd.Run()
+
+	if tc.ExpectedError != "" {
+		if err == nil {
+			t.Fatalf("expected to fail with error %q, but it succeeded", tc.ExpectedError)
+		}
+		if !strings.Contains(out.String(), tc.ExpectedError) {
+			t.Errorf("expected output to contain %q, got %q", tc.ExpectedError, out.String())
+		}
+		return
+	}
+
 	if err != nil {
 		t.Fatalf("failed to run tako graph: %v\nOutput:\n%s", err, out.String())
 	}


### PR DESCRIPTION
### Description

This change introduces circular dependency detection to the graph building process. If a cycle is detected, the command will fail with a clear error message that identifies the repositories involved in the cycle.

This change also includes:
- A new `CircularDependencyError` to provide detailed information about the detected cycle.
- Unit and E2E tests to validate the cycle detection logic.
- Fixes for linter and formatting issues.

### How to Test

1.  Check out this branch: `git checkout issue/12`
2.  Run the tests: `go test -v ./...`
3.  Run the E2E tests: `go test -v -tags=e2e --local ./...`
4.  Create a circular dependency in a `tako.yml` file and run `tako graph` to see the error message.

Fixes: #12
