### PR TITLE
feat(config): use maps for artifacts and workflows

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,11 @@ import (
 )
 
 type TakoConfig struct {
-	Version    string               `yaml:"version"`
-	Metadata   Metadata             `yaml:"metadata"`
-	Artifacts  map[string]Artifact  `yaml:"artifacts"`
-	Dependents []Dependent          `yaml:"dependents"`
-	Workflows  map[string]Workflow  `yaml:"workflows"`
+	Version    string              `yaml:"version"`
+	Metadata   Metadata            `yaml:"metadata"`
+	Artifacts  map[string]Artifact `yaml:"artifacts"`
+	Dependents []Dependent         `yaml:"dependents"`
+	Workflows  map[string]Workflow `yaml:"workflows"`
 }
 
 type Metadata struct {
@@ -21,6 +21,7 @@ type Metadata struct {
 }
 
 type Artifact struct {
+	Name           string `yaml:"-"`
 	Description    string `yaml:"description"`
 	Image          string `yaml:"image"`
 	Command        string `yaml:"command"`
@@ -36,6 +37,7 @@ type Dependent struct {
 }
 
 type Workflow struct {
+	Name      string    `yaml:"-"`
 	Image     string    `yaml:"image"`
 	Env       []string  `yaml:"env"`
 	Resources Resources `yaml:"resources"`
@@ -56,6 +58,16 @@ func Load(path string) (*TakoConfig, error) {
 	var config TakoConfig
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("could not unmarshal config: %w", err)
+	}
+
+	for name, artifact := range config.Artifacts {
+		artifact.Name = name
+		config.Artifacts[name] = artifact
+	}
+
+	for name, workflow := range config.Workflows {
+		workflow.Name = name
+		config.Workflows[name] = workflow
 	}
 
 	if err := validate(&config); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -118,3 +118,41 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoad_PopulatesName(t *testing.T) {
+	yamlContent := `
+version: "1.0"
+artifacts:
+  my-artifact:
+    description: "An artifact"
+workflows:
+  my-workflow:
+    steps:
+      - "echo hello"
+dependents: []
+`
+	tmpfile, err := os.CreateTemp(t.TempDir(), "tako.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(yamlContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := Load(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if config.Artifacts["my-artifact"].Name != "my-artifact" {
+		t.Errorf("expected artifact name to be 'my-artifact', got %q", config.Artifacts["my-artifact"].Name)
+	}
+
+	if config.Workflows["my-workflow"].Name != "my-workflow" {
+		t.Errorf("expected workflow name to be 'my-workflow', got %q", config.Workflows["my-workflow"].Name)
+	}
+}

--- a/test/e2e/testcase.go
+++ b/test/e2e/testcase.go
@@ -43,6 +43,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-b:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -53,6 +55,8 @@ func GetTestCases(owner string) map[string]TestCase {
 							Name: "repo-b",
 						},
 						Dependents: []config.Dependent{},
+						Artifacts:  map[string]config.Artifact{},
+						Workflows:  map[string]config.Workflow{},
 					},
 				},
 			},
@@ -72,6 +76,8 @@ func GetTestCases(owner string) map[string]TestCase {
 							{Repo: "repo-b:main"},
 							{Repo: "repo-d:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -84,6 +90,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-c:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -96,6 +104,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-e:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -108,6 +118,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-e:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -118,6 +130,8 @@ func GetTestCases(owner string) map[string]TestCase {
 							Name: "repo-e",
 						},
 						Dependents: []config.Dependent{},
+						Artifacts:  map[string]config.Artifact{},
+						Workflows:  map[string]config.Workflow{},
 					},
 				},
 			},
@@ -136,6 +150,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-y:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -148,6 +164,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-z:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -158,6 +176,8 @@ func GetTestCases(owner string) map[string]TestCase {
 							Name: "repo-z",
 						},
 						Dependents: []config.Dependent{},
+						Artifacts:  map[string]config.Artifact{},
+						Workflows:  map[string]config.Workflow{},
 					},
 				},
 			},
@@ -177,6 +197,8 @@ func GetTestCases(owner string) map[string]TestCase {
 							{Repo: "repo-b:main"},
 							{Repo: "repo-d:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -189,6 +211,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-c:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -201,6 +225,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-e:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -213,6 +239,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-e:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -223,6 +251,8 @@ func GetTestCases(owner string) map[string]TestCase {
 							Name: "repo-e",
 						},
 						Dependents: []config.Dependent{},
+						Artifacts:  map[string]config.Artifact{},
+						Workflows:  map[string]config.Workflow{},
 					},
 				},
 			},
@@ -241,6 +271,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-circ-b:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 				{
@@ -253,6 +285,8 @@ func GetTestCases(owner string) map[string]TestCase {
 						Dependents: []config.Dependent{
 							{Repo: "repo-circ-a:main"},
 						},
+						Artifacts: map[string]config.Artifact{},
+						Workflows: map[string]config.Workflow{},
 					},
 				},
 			},


### PR DESCRIPTION
This change modifies the `tako.yml` schema to use maps instead of slices for `artifacts` and `workflows`. This is a more intuitive and user-friendly approach.

The `Name` field in the `Artifact` and `Workflow` structs is now populated from the map key during the unmarshalling process and is not persisted in the YAML file.

Fixes #76