### PR TITLE
feat(errors): implement structured error handling and retry logic

### DIFF
--- a/cmd/takotest/internal/cleanup.go
+++ b/cmd/takotest/internal/cleanup.go
@@ -24,7 +24,11 @@ func NewCleanupCmd() *cobra.Command {
 				return fmt.Errorf("environment not found: %s", envName)
 			}
 
+			preserveTmp, _ := cmd.Flags().GetBool("preserve-tmp")
 			if local {
+				if preserveTmp {
+					return nil
+				}
 				tmpDir := filepath.Join(os.TempDir(), env.Name)
 				return os.RemoveAll(tmpDir)
 			}
@@ -47,6 +51,7 @@ func NewCleanupCmd() *cobra.Command {
 	}
 	cmd.Flags().String("owner", "", "The owner of the repositories")
 	cmd.Flags().Bool("local", false, "Cleanup the test case locally")
+	cmd.Flags().Bool("preserve-tmp", false, "Preserve the temporary directory")
 	cmd.MarkFlagRequired("owner")
 	return cmd
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -20,9 +20,10 @@ import (
 const testOrg = "tako-test"
 
 var (
-	local      = flag.Bool("local", false, "run local tests")
-	remote     = flag.Bool("remote", false, "run remote tests")
-	entrypoint = flag.String("entrypoint", "all", "entrypoint mode to run tests in (all, path, repo)")
+	local        = flag.Bool("local", false, "run local tests")
+	remote       = flag.Bool("remote", false, "run remote tests")
+	entrypoint   = flag.String("entrypoint", "all", "entrypoint mode to run tests in (all, path, repo)")
+	preserveTmp = flag.Bool("preserve-tmp", false, "preserve temporary directories")
 )
 
 func findProjectRoot(start string) string {
@@ -208,6 +209,9 @@ func cleanupEnvironment(t *testing.T, takotestPath, envName, mode, workDir, cach
 	var cleanupArgs []string
 	if mode == "local" {
 		cleanupArgs = append(cleanupArgs, "--local")
+	}
+	if *preserveTmp {
+		cleanupArgs = append(cleanupArgs, "--preserve-tmp")
 	}
 	cleanupArgs = append(cleanupArgs, "--owner", testOrg, envName)
 	cleanupCmd := exec.Command(takotestPath, append([]string{"cleanup"}, cleanupArgs...)...)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,28 @@
+package errors
+
+import "fmt"
+
+type TakoError struct {
+	Code    string
+	Message string
+	Err     error
+}
+
+func (e *TakoError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s - %v", e.Code, e.Message, e.Err)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (e *TakoError) Unwrap() error {
+	return e.Err
+}
+
+func New(code, message string) *TakoError {
+	return &TakoError{Code: code, Message: message}
+}
+
+func Wrap(err error, code, message string) *TakoError {
+	return &TakoError{Code: code, Message: message, Err: err}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,20 +2,22 @@ package git
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+	"github.com/dangazineu/tako/internal/errors"
 )
 
 // Clone clones a repository from the given url into the given path.
 func Clone(url, path string) error {
-	cmd := exec.Command("git", "clone", url, path)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to clone repo %s: %s", url, string(output))
+	var err error
+	for i := 0; i < 3; i++ {
+		cmd := exec.Command("git", "clone", url, path)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		err = errors.Wrap(err, "TAKO_E001", fmt.Sprintf("failed to clone repo %s: %s", url, string(output)))
+		time.Sleep(2 * time.Second)
 	}
-	return nil
+	return err
 }
 
 // Checkout checks out a specific ref in the given repository path.
@@ -23,7 +25,7 @@ func Checkout(path, ref string) error {
 	cmd := exec.Command("git", "-C", path, "checkout", ref)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to checkout ref %s in %s: %s", ref, path, string(output))
+		return errors.Wrap(err, "TAKO_E002", fmt.Sprintf("failed to checkout ref %s in %s: %s", ref, path, string(output)))
 	}
 	return nil
 }
@@ -38,7 +40,7 @@ func GetEntrypointPath(root, repo, cacheDir string, localOnly bool) (string, err
 		var err error
 		root, err = os.Getwd()
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "TAKO_E003", "failed to get current working directory")
 		}
 	}
 	return root, nil
@@ -69,14 +71,14 @@ func GetRepoPath(repo, currentPath, cacheDir string, localOnly bool) (string, er
 		if cacheDir == "~/.tako/cache" {
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
-				return "", fmt.Errorf("failed to get home dir: %w", err)
+				return "", errors.Wrap(err, "TAKO_E004", "failed to get home dir")
 			}
 			cacheDir = filepath.Join(homeDir, ".tako", "cache")
 		}
 
 		repoParts := strings.Split(repo, "/")
 		if len(repoParts) < 2 {
-			return "", fmt.Errorf("invalid remote repository format: %s", repo)
+			return "", errors.New("TAKO_E005", fmt.Sprintf("invalid remote repository format: %s", repo))
 		}
 		repoOwner := repoParts[0]
 
@@ -102,7 +104,7 @@ func GetRepoPath(repo, currentPath, cacheDir string, localOnly bool) (string, er
 				// Fallback to cache if not found in the immediate test structure
 				repoPath = filepath.Join(cacheDir, "repos", repoOwner, repoName)
 				if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-					return "", fmt.Errorf("repository %s not found in cache or local test structure", repo)
+					return "", errors.Wrap(err, "TAKO_E006", fmt.Sprintf("repository %s not found in cache or local test structure", repo))
 				}
 			}
 		} else {
@@ -116,7 +118,7 @@ func GetRepoPath(repo, currentPath, cacheDir string, localOnly bool) (string, er
 			} else {
 				cmd := exec.Command("git", "-C", repoPath, "fetch")
 				if err := cmd.Run(); err != nil {
-					return "", fmt.Errorf("failed to update repo %s: %w", repo, err)
+					return "", errors.Wrap(err, "TAKO_E007", fmt.Sprintf("failed to update repo %s", repo))
 				}
 			}
 			if ref != "" {


### PR DESCRIPTION
### Description

This change introduces a more robust error handling framework and improves the resilience of Git operations, addressing the requirements of issue #20.

-   **Retry Logic:** The `git clone` operation will now retry up to 3 times with a 2-second delay on transient failures, making it more resilient to temporary network issues.
-   **Structured Errors:** A new `TakoError` type with a unique error code (e.g., `TAKO_E001`) has been introduced. All application-level errors in the `git` package have been refactored to use this new structured error, making them easier to identify and debug.
-   **Debuggability:** A `--preserve-tmp` flag has been added to the E2E test suite. When used, it prevents the cleanup of temporary directories, allowing for post-mortem inspection of the test environment after a failure.

Fixes: #20

### How to Test

1.  **Verify Retry Logic (Manual):**
    *   To manually simulate a network failure, you can temporarily disconnect your network and run a `tako` command that triggers a `git clone` (e.g., `tako graph --repo some/new-repo:main`). The command should fail after 3 attempts. Reconnect and run it again to confirm it succeeds.

2.  **Verify Structured Errors:**
    *   Run the E2E test suite with the `-v` flag: `go test -v -tags=e2e --local ./...`
    *   Intentionally introduce a failure (e.g., by providing an invalid repository name in `test/e2e/environments.go`).
    *   Observe that the test fails with a structured error code (e.g., `TAKO_E001`).

3.  **Verify Temporary File Preservation:**
    *   Run a failing E2E test with the new flag: `go test -v -tags=e2e --local ./... --preserve-tmp`
    *   After the test fails, inspect your system's temporary directory (e.g., `/tmp` on Linux/macOS).
    *   Confirm that the test's temporary directories (e.g., `/tmp/TestE2E...`) have **not** been deleted, allowing you to inspect logs and artifacts.
    *   Run the tests again without the flag to confirm the directories are cleaned up as usual.
