### PR TITLE
feat(run): implement repository filtering with --only and --ignore flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,14 @@ go 1.24.4
 require (
 	github.com/google/go-github/v63 v63.0.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -8,11 +10,15 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- Implements repository filtering functionality for the `tako run` command with `--only` and `--ignore` flags
- Adds comprehensive filtering logic in the graph package with proper handling of edge cases
- Includes extensive test coverage for all filtering scenarios including error cases

## Test plan
**Automated tests:**
```bash
go test -v ./...
go test -v -tags=integration ./...
go test -v -tags=e2e --local ./...
go test -v -tags=e2e --remote ./...
```

**Manual testing (remote mode):**

1. **Install updated tako binary** - Build and install the version with filtering flags:
   ```bash
   go install ./cmd/tako
   ```

2. **Setup test environment** - Create remote repositories with 3-level dependency chain:
   ```bash
   takotest setup deep-graph --owner tako-test
   ```
   This creates: `repo-x` → `repo-y` → `repo-z` dependency chain:
   - `tako-test/deep-graph-repo-x` (depends on repo-y)
   - `tako-test/deep-graph-repo-y` (depends on repo-z)  
   - `tako-test/deep-graph-repo-z` (no dependencies)

3. **Test --only flag at different dependency levels:**
   ```bash
   # Test --only with top-level repo (should run in all 3: x, y, z)
   tako run --repo tako-test/deep-graph-repo-x:main --only deep-graph-repo-x "echo 'Repository:' && grep 'name:' tako.yml | sed 's/.*name: *//'"
   
   # Test --only with middle-level repo (should run in 2: y, z)
   tako run --repo tako-test/deep-graph-repo-x:main --only deep-graph-repo-y "echo 'Repository:' && grep 'name:' tako.yml | sed 's/.*name: *//'"
   
   # Test --only with leaf-level repo (should run in 1: z only)
   tako run --repo tako-test/deep-graph-repo-x:main --only deep-graph-repo-z "echo 'Repository:' && grep 'name:' tako.yml | sed 's/.*name: *//'"
   ```

4. **Test --ignore flag at different dependency levels:**
   ```bash
   # Test --ignore middle repo (should run only in x, skipping y and z)
   tako run --repo tako-test/deep-graph-repo-x:main --ignore deep-graph-repo-y "echo 'Repository:' && grep 'name:' tako.yml | sed 's/.*name: *//'"
   
   # Test --ignore leaf repo (should run in x and y, skipping only z)
   tako run --repo tako-test/deep-graph-repo-x:main --ignore deep-graph-repo-z "echo 'Repository:' && grep 'name:' tako.yml | sed 's/.*name: *//'"
   ```

5. **Test combination of flags:**
   ```bash
   # Combine --only and --ignore (should run only in x)
   tako run --repo tako-test/deep-graph-repo-x:main --only deep-graph-repo-x --ignore deep-graph-repo-y "echo 'Repository:' && grep 'name:' tako.yml | sed 's/.*name: *//'"
   ```

6. **Test error cases:**
   ```bash
   # Non-existent repository in --only
   tako run --repo tako-test/deep-graph-repo-x:main --only non-existent-repo "echo test"
   
   # Non-existent repository in --ignore  
   tako run --repo tako-test/deep-graph-repo-x:main --ignore non-existent-repo "echo test"
   ```
   Expected: Both should fail with "repository \"non-existent-repo\" not found in the graph" error

7. **Cleanup** - Remove test repositories:
   ```bash
   takotest cleanup deep-graph --owner tako-test
   ```

**Expected behavior:** The 3-level dependency chain allows comprehensive testing of filtering at different dependency levels, demonstrating that `--only` includes dependents and `--ignore` excludes dependents as designed.

Fixes #18