### PR TITLE
feat(run): implement --dry-run flag for command preview

### DIFF
--- a/cmd/tako/internal/run_test.go
+++ b/cmd/tako/internal/run_test.go
@@ -125,3 +125,18 @@ func TestRunCmd_Filtering(t *testing.T) {
 		})
 	}
 }
+
+func TestRunCmd_DryRun(t *testing.T) {
+	cmd := NewRunCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	// Test that the --dry-run flag is available
+	err := cmd.Flags().Set("dry-run", "true")
+	require.NoError(t, err)
+
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	require.NoError(t, err)
+	assert.True(t, dryRun)
+}

--- a/test/e2e/get_test_cases.go
+++ b/test/e2e/get_test_cases.go
@@ -31,6 +31,39 @@ func GetTestCases() []TestCase {
 					Args:    []string{"run", "echo 'hello' > test.txt"},
 				},
 			},
+			Verify: Verification{
+				Files: []VerifyFileExists{
+					{
+						FileName:        "test.txt",
+						ShouldExist:     true,
+						ExpectedContent: "hello",
+					},
+				},
+			},
+		},
+		{
+			Name:        "run-dry-run-prevents-execution",
+			Environment: "simple-graph",
+			ReadOnly:    true,
+			Test: []Step{
+				{
+					Name:         "tako run with dry-run flag",
+					Command:      "tako",
+					Args:         []string{"run", "--dry-run", "echo 'hello' > dry-run-test.txt"},
+					AssertOutput: true,
+					ExpectedOutput: `[dry-run] {{.Repo.repo-a}}: echo 'hello' > dry-run-test.txt
+[dry-run] {{.Repo.repo-b}}: echo 'hello' > dry-run-test.txt
+`,
+				},
+			},
+			Verify: Verification{
+				Files: []VerifyFileExists{
+					{
+						FileName:    "dry-run-test.txt",
+						ShouldExist: false,
+					},
+				},
+			},
 		},
 		{
 			Name:        "java-binary-incompatibility",

--- a/test/e2e/testcase.go
+++ b/test/e2e/testcase.go
@@ -11,11 +11,24 @@ type Step struct {
 	ExpectedExitCode     int      // Defaults to 0
 }
 
+// VerifyFileExists checks if a file exists and optionally verifies its content.
+type VerifyFileExists struct {
+	FileName        string // Name of the file to check (relative to repo root)
+	ShouldExist     bool   // Whether the file should exist
+	ExpectedContent string // Expected content (optional, only checked if ShouldExist is true)
+}
+
+// Verification defines what to verify after test execution.
+type Verification struct {
+	Files []VerifyFileExists // Files to check in each repository
+}
+
 // TestCase defines a multi-step test to run within an environment.
 type TestCase struct {
 	Name        string
-	Environment string // The name of the TestEnvironmentDef to use
-	ReadOnly    bool   // If true, this test does not modify the environment
-	Setup       []Step // Optional steps to run before the main test
-	Test        []Step // The core test steps
+	Environment string       // The name of the TestEnvironmentDef to use
+	ReadOnly    bool         // If true, this test does not modify the environment
+	Setup       []Step       // Optional steps to run before the main test
+	Test        []Step       // The core test steps
+	Verify      Verification // What to verify after execution
 }


### PR DESCRIPTION
## Summary
- Implements `--dry-run` flag for the `tako run` command to preview command execution without making changes
- Shows commands in format `[dry-run] repo-name: command` while preserving dependency order
- Adds comprehensive E2E testing with data-driven verification framework
- Enhances test infrastructure to verify both positive and negative file creation scenarios

## Test plan
**Automated tests:**
```bash
go test -v ./...
go test -v -tags=integration ./...
go test -v -tags=e2e --local ./...
go test -v -tags=e2e --remote ./...
```

**Manual testing (local mode):**

1. **Install updated tako binary:**
   ```bash
   go install ./cmd/tako
   ```

2. **Setup test environment:**
   ```bash
   mkdir -p test-temp && takotest setup simple-graph --owner tako-test --local --work-dir ./test-temp --cache-dir ./test-temp/cache
   ```

3. **Test dry-run flag shows preview without execution:**
   ```bash
   tako run --cache-dir ./test-temp/cache --repo tako-test/simple-graph-repo-b:main --local --dry-run "echo 'Creating test file' && touch dry-run-test.txt"
   ```
   **Expected output:**
   ```
   [dry-run] simple-graph-repo-b: echo 'Creating test file' && touch dry-run-test.txt
   ```

4. **Verify no files were created during dry-run:**
   ```bash
   find ./test-temp -name "dry-run-test.txt" | wc -l
   ```
   **Expected result:** `0` (no files found)

5. **Test normal execution creates files:**
   ```bash
   tako run --cache-dir ./test-temp/cache --repo tako-test/simple-graph-repo-b:main --local "echo 'Creating test file' && touch normal-test.txt"
   
   find ./test-temp -name "normal-test.txt" | wc -l
   ```
   **Expected result:** `1` (file created)

6. **Verify help text shows dry-run flag:**
   ```bash
   tako run --help | grep "dry-run"
   ```
   **Expected output:** Should show `--dry-run` flag description

7. **Cleanup:**
   ```bash
   takotest cleanup simple-graph --owner tako-test --local && rm -rf ./test-temp
   ```

**Expected behavior:** The dry-run flag provides a safe preview of what commands would be executed without making any actual changes to the filesystem, while maintaining the correct execution order and respecting all filtering flags.

Fixes #19