### PR TITLE
refactor: restrict flag and environment variable parsing to cmd packages

### DIFF
--- a/cmd/tako/internal/graph.go
+++ b/cmd/tako/internal/graph.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dangazineu/tako/internal/git"
 	"github.com/dangazineu/tako/internal/graph"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 func NewGraphCmd() *cobra.Command {
@@ -17,12 +18,21 @@ func NewGraphCmd() *cobra.Command {
 			dot, _ := cmd.Flags().GetBool("dot")
 			cacheDir, _ := cmd.InheritedFlags().GetString("cache-dir")
 
-			entrypointPath, err := git.GetEntrypointPath(root, repo, cacheDir, local)
+			workingDir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return err
 			}
 
-			rootNode, err := graph.BuildGraph(entrypointPath, cacheDir, local)
+			entrypointPath, err := git.GetEntrypointPath(root, repo, cacheDir, workingDir, homeDir, local)
+			if err != nil {
+				return err
+			}
+
+			rootNode, err := graph.BuildGraph(entrypointPath, cacheDir, homeDir, local)
 			if err != nil {
 				if _, ok := err.(*graph.CircularDependencyError); ok {
 					return err

--- a/cmd/tako/internal/run.go
+++ b/cmd/tako/internal/run.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dangazineu/tako/internal/git"
 	"github.com/dangazineu/tako/internal/graph"
 	"github.com/spf13/cobra"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -30,12 +31,21 @@ func NewRunCmd() *cobra.Command {
 				}
 			}
 
-			entrypointPath, err := git.GetEntrypointPath(root, repo, cacheDir, local)
+			workingDir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return err
 			}
 
-			rootNode, err := graph.BuildGraph(entrypointPath, cacheDir, local)
+			entrypointPath, err := git.GetEntrypointPath(root, repo, cacheDir, workingDir, homeDir, local)
+			if err != nil {
+				return err
+			}
+
+			rootNode, err := graph.BuildGraph(entrypointPath, cacheDir, homeDir, local)
 			if err != nil {
 				return err
 			}

--- a/cmd/tako/internal/validate.go
+++ b/cmd/tako/internal/validate.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/dangazineu/tako/internal/config"
@@ -20,7 +21,16 @@ func NewValidateCmd() *cobra.Command {
 			local, _ := cmd.Flags().GetBool("local")
 			cacheDir, _ := cmd.InheritedFlags().GetString("cache-dir")
 
-			entrypointPath, err := git.GetEntrypointPath(root, repo, cacheDir, local)
+			workingDir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+
+			entrypointPath, err := git.GetEntrypointPath(root, repo, cacheDir, workingDir, homeDir, local)
 			if err != nil {
 				return err
 			}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -102,7 +102,7 @@ func TestGetEntrypointPath(t *testing.T) {
 			t.Fatalf("failed to create repo path: %v", err)
 		}
 
-		path, err := git.GetEntrypointPath("", "owner/repo:main", cacheDir, true)
+		path, err := git.GetEntrypointPath("", "owner/repo:main", cacheDir, "", "", true)
 		if err != nil {
 			t.Fatalf("failed to get entrypoint path: %v", err)
 		}
@@ -116,7 +116,7 @@ func TestGetEntrypointPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get working directory: %v", err)
 		}
-		path, err := git.GetEntrypointPath("", "", "", false)
+		path, err := git.GetEntrypointPath("", "", "", wd, "", false)
 		if err != nil {
 			t.Fatalf("failed to get entrypoint path: %v", err)
 		}
@@ -146,7 +146,7 @@ func TestGetRepoPath_BranchSpecificCaching(t *testing.T) {
 		}
 
 		// Test main branch
-		mainPath, err := git.GetRepoPath("owner/repo:main", "", cacheDir, true)
+		mainPath, err := git.GetRepoPath("owner/repo:main", "", cacheDir, "", true)
 		if err != nil {
 			t.Fatalf("failed to get repo path for main branch: %v", err)
 		}
@@ -155,7 +155,7 @@ func TestGetRepoPath_BranchSpecificCaching(t *testing.T) {
 		}
 
 		// Test dev branch
-		devPath, err := git.GetRepoPath("owner/repo:dev", "", cacheDir, true)
+		devPath, err := git.GetRepoPath("owner/repo:dev", "", cacheDir, "", true)
 		if err != nil {
 			t.Fatalf("failed to get repo path for dev branch: %v", err)
 		}
@@ -178,7 +178,7 @@ func TestGetRepoPath_BranchSpecificCaching(t *testing.T) {
 		}
 
 		// Test without branch specified (should default to main)
-		path, err := git.GetRepoPath("owner/test-repo", "", cacheDir, true)
+		path, err := git.GetRepoPath("owner/test-repo", "", cacheDir, "", true)
 		if err != nil {
 			t.Fatalf("failed to get repo path for default branch: %v", err)
 		}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -206,11 +206,11 @@ func (n *Node) Filter(only, ignore []string) (*Node, error) {
 	return &Node{Name: "empty-root", Path: ""}, nil
 }
 
-func BuildGraph(path, cacheDir string, localOnly bool) (*Node, error) {
-	return buildGraphRecursive(path, cacheDir, make(map[string]*Node), []string{}, []string{}, localOnly)
+func BuildGraph(path, cacheDir, homeDir string, localOnly bool) (*Node, error) {
+	return buildGraphRecursive(path, cacheDir, homeDir, make(map[string]*Node), []string{}, []string{}, localOnly)
 }
 
-func buildGraphRecursive(path, cacheDir string, visited map[string]*Node, currentPath []string, currentPathNames []string, localOnly bool) (*Node, error) {
+func buildGraphRecursive(path, cacheDir, homeDir string, visited map[string]*Node, currentPath []string, currentPathNames []string, localOnly bool) (*Node, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
@@ -247,12 +247,12 @@ func buildGraphRecursive(path, cacheDir string, visited map[string]*Node, curren
 	newPathNames := append(currentPathNames, root.Name)
 
 	for _, dependent := range cfg.Dependents {
-		repoPath, err := git.GetRepoPath(dependent.Repo, absPath, cacheDir, localOnly)
+		repoPath, err := git.GetRepoPath(dependent.Repo, absPath, cacheDir, homeDir, localOnly)
 		if err != nil {
 			return nil, err
 		}
 
-		child, err := buildGraphRecursive(repoPath, cacheDir, visited, newPath, newPathNames, localOnly)
+		child, err := buildGraphRecursive(repoPath, cacheDir, homeDir, visited, newPath, newPathNames, localOnly)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -194,7 +194,7 @@ dependents:
 		t.Fatal(err)
 	}
 
-	_, err := BuildGraph(repoA, cacheDir, true)
+	_, err := BuildGraph(repoA, cacheDir, "", true)
 	if err == nil {
 		t.Fatal("Expected an error, but got nil")
 	}


### PR DESCRIPTION
This change implements proper separation of concerns by restricting flag and environment variable parsing to cmd packages only, with internal packages receiving parsed values as parameters.

## Summary

- Added comprehensive linter tests to enforce restriction of flag/env parsing to cmd packages
- Refactored `internal/git` functions to accept `workingDir` and `homeDir` parameters instead of calling `os.Getwd()` and `os.UserHomeDir()`
- Updated cmd packages to get system paths and pass them to internal packages
- Maintained backward compatibility and functionality
- Enhanced code architecture with proper dependency injection

## Changes Made

- **linter_test.go**: Added `TestNoEnvironmentVariableAccess` and `TestNoFlagParsingAccess` to enforce the restriction
- **internal/git/git.go**: Refactored `GetEntrypointPath` and `GetRepoPath` to accept `workingDir` and `homeDir` parameters
- **internal/graph/graph.go**: Updated `BuildGraph` to accept and pass `homeDir` parameter  
- **cmd/tako/internal/{validate,run,graph}.go**: Updated to get system paths via `os.Getwd()` and `os.UserHomeDir()` and pass them to internal packages
- **Test files**: Updated function signatures to match new parameters

Fixes #82