### PR TITLE
feat: implement event-driven workflow engine for issue #99

### DIFF
--- a/cmd/takotest/internal/setup.go
+++ b/cmd/takotest/internal/setup.go
@@ -180,6 +180,7 @@ func setupRemote(cmd *cobra.Command, env *e2e.TestEnvironmentDef, owner string) 
 			Metadata: config.Metadata{
 				Name: repoName,
 			},
+			Dependents: []config.Dependent{}, // Initialize empty slice for repos with no dependencies
 		}
 		for _, dep := range repoDef.Dependencies {
 			takoConfig.Dependents = append(takoConfig.Dependents, config.Dependent{Repo: fmt.Sprintf("%s/%s-%s:main", owner, env.Name, dep)})
@@ -246,6 +247,7 @@ func createRepoFiles(repoPath string, repoDef *e2e.RepositoryDef, envName, owner
 		Metadata: config.Metadata{
 			Name: fmt.Sprintf("%s-%s", envName, repoDef.Name),
 		},
+		Dependents: []config.Dependent{}, // Initialize empty slice for repos with no dependencies
 	}
 	for _, dep := range repoDef.Dependencies {
 		takoConfig.Dependents = append(takoConfig.Dependents, config.Dependent{Repo: fmt.Sprintf("%s/%s-%s:main", owner, envName, dep)})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,14 +91,14 @@ type WorkflowStep struct {
 	OnFailure     []WorkflowStep         `yaml:"on_failure,omitempty"`      // Steps to run on failure
 }
 
-// WorkflowStepProduces represents what a step produces (outputs, artifacts, events)
+// WorkflowStepProduces represents what a step produces (outputs, artifacts, events).
 type WorkflowStepProduces struct {
 	Artifact string            `yaml:"artifact,omitempty"` // Artifact name produced
 	Outputs  map[string]string `yaml:"outputs,omitempty"`  // Output mappings
 	Events   []Event           `yaml:"events,omitempty"`   // Events to emit
 }
 
-// UnmarshalYAML implements custom YAML unmarshaling for WorkflowStep to support backward compatibility
+// UnmarshalYAML implements custom YAML unmarshaling for WorkflowStep to support backward compatibility.
 func (step *WorkflowStep) UnmarshalYAML(node *yaml.Node) error {
 	// If the node is a string, this is a legacy simple step
 	if node.Kind == yaml.ScalarNode {
@@ -214,7 +214,7 @@ func validateArtifacts(dependentArtifacts []string, definedArtifacts map[string]
 	return nil
 }
 
-// validateWorkflow validates a single workflow definition
+// validateWorkflow validates a single workflow definition.
 func validateWorkflow(_ string, workflow *Workflow) error {
 	// Validate workflow inputs
 	for inputName, input := range workflow.Inputs {
@@ -233,7 +233,7 @@ func validateWorkflow(_ string, workflow *Workflow) error {
 	return nil
 }
 
-// validateWorkflowInput validates a workflow input definition
+// validateWorkflowInput validates a workflow input definition.
 func validateWorkflowInput(_ string, input *WorkflowInput) error {
 	// Validate input type
 	if input.Type != "" {
@@ -263,7 +263,7 @@ func validateWorkflowInput(_ string, input *WorkflowInput) error {
 	return nil
 }
 
-// validateWorkflowStep validates a single workflow step
+// validateWorkflowStep validates a single workflow step.
 func validateWorkflowStep(_ int, step *WorkflowStep) error {
 	// Either 'run' or 'uses' must be specified, but not both
 	if step.Run == "" && step.Uses == "" {
@@ -297,7 +297,7 @@ func validateWorkflowStep(_ int, step *WorkflowStep) error {
 	return nil
 }
 
-// validateWorkflowStepProduces validates the produces section of a step
+// validateWorkflowStepProduces validates the produces section of a step.
 func validateWorkflowStepProduces(produces *WorkflowStepProduces) error {
 	// Validate output formats
 	for outputName, outputValue := range produces.Outputs {
@@ -339,7 +339,7 @@ var knownBuiltinSteps = map[string][]string{
 	"tako/poll":                {"v1"},
 }
 
-// validateBuiltinStep validates that a built-in step is known and uses a supported version
+// validateBuiltinStep validates that a built-in step is known and uses a supported version.
 func validateBuiltinStep(uses string) error {
 	parts := strings.Split(uses, "@")
 	if len(parts) != 2 {
@@ -363,7 +363,7 @@ func validateBuiltinStep(uses string) error {
 	return fmt.Errorf("built-in step '%s' version '%s' is not supported. Supported versions: %v", stepName, version, supportedVersions)
 }
 
-// validateCELExpression validates CEL expression syntax (basic validation)
+// validateCELExpression validates CEL expression syntax (basic validation).
 func validateCELExpression(expression string) error {
 	// Basic validation for common CEL patterns
 	// This is a simplified validation - in production, you'd use the actual CEL library
@@ -401,7 +401,7 @@ func validateCELExpression(expression string) error {
 	return nil
 }
 
-// validateSemverRange validates semantic version range syntax
+// validateSemverRange validates semantic version range syntax.
 func validateSemverRange(versionRange string) error {
 	if versionRange == "" {
 		return nil // Empty version range is valid
@@ -429,7 +429,7 @@ func validateSemverRange(versionRange string) error {
 	return fmt.Errorf("invalid version range format '%s'. Supported formats: ^1.0.0, ~1.0.0, 1.0.0, (1.0.0...2.0.0], [1.0.0...2.0.0)", versionRange)
 }
 
-// validateTemplateExpression validates template expressions in payload fields
+// validateTemplateExpression validates template expressions in payload fields.
 func validateTemplateExpression(expression string) error {
 	if !strings.Contains(expression, "{{") {
 		return nil // Not a template expression

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ type TakoConfig struct {
 	Version       string              `yaml:"version"`
 	Metadata      Metadata            `yaml:"metadata"`
 	Artifacts     map[string]Artifact `yaml:"artifacts"`
-	Dependents    []Dependent         `yaml:"dependents,omitempty"` // Legacy field, optional for backward compatibility
+	Dependents    []Dependent         `yaml:"dependents"` // Legacy field, still required for graph functionality
 	Workflows     map[string]Workflow `yaml:"workflows"`
 	Subscriptions []Subscription      `yaml:"subscriptions,omitempty"` // New event-driven subscriptions
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
-	"strings"
 	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -28,7 +28,7 @@ type Artifact struct {
 	Image          string `yaml:"image"`
 	Command        string `yaml:"command"`
 	Path           string `yaml:"path"`
-	Ecosystem      string `yaml:"ecosystem,omitempty"`      // New field for artifact ecosystem (go, npm, maven, etc.)
+	Ecosystem      string `yaml:"ecosystem,omitempty"` // New field for artifact ecosystem (go, npm, maven, etc.)
 	InstallCommand string `yaml:"install_command"`
 	VerifyCommand  string `yaml:"verify_command"`
 }
@@ -40,14 +40,14 @@ type Dependent struct {
 }
 
 type Workflow struct {
-	Name      string                 `yaml:"-"`
-	On        string                 `yaml:"on,omitempty"`        // Trigger condition ("exec" for manual workflows)
-	Image     string                 `yaml:"image,omitempty"`
-	Env       []string               `yaml:"env,omitempty"`
-	Secrets   []string               `yaml:"secrets,omitempty"`   // List of secret names
-	Resources Resources              `yaml:"resources,omitempty"`
-	Inputs    map[string]WorkflowInput `yaml:"inputs,omitempty"`    // Input definitions
-	Steps     []WorkflowStep         `yaml:"steps,omitempty"`     // Updated to support rich step definitions
+	Name      string                   `yaml:"-"`
+	On        string                   `yaml:"on,omitempty"` // Trigger condition ("exec" for manual workflows)
+	Image     string                   `yaml:"image,omitempty"`
+	Env       []string                 `yaml:"env,omitempty"`
+	Secrets   []string                 `yaml:"secrets,omitempty"` // List of secret names
+	Resources Resources                `yaml:"resources,omitempty"`
+	Inputs    map[string]WorkflowInput `yaml:"inputs,omitempty"` // Input definitions
+	Steps     []WorkflowStep           `yaml:"steps,omitempty"`  // Updated to support rich step definitions
 }
 
 type Resources struct {
@@ -58,44 +58,44 @@ type Resources struct {
 	DiskLimit string `yaml:"disk_limit,omitempty"` // Disk space limit
 }
 
-// WorkflowInput represents an input parameter for a workflow
+// WorkflowInput represents an input parameter for a workflow.
 type WorkflowInput struct {
-	Type        string                 `yaml:"type,omitempty"`        // Input type (string, boolean, number)
-	Description string                 `yaml:"description,omitempty"` // Human-readable description
-	Required    bool                   `yaml:"required,omitempty"`    // Whether input is required
-	Default     interface{}            `yaml:"default,omitempty"`     // Default value
+	Type        string                  `yaml:"type,omitempty"`        // Input type (string, boolean, number)
+	Description string                  `yaml:"description,omitempty"` // Human-readable description
+	Required    bool                    `yaml:"required,omitempty"`    // Whether input is required
+	Default     interface{}             `yaml:"default,omitempty"`     // Default value
 	Validation  WorkflowInputValidation `yaml:"validation,omitempty"`  // Validation rules
 }
 
-// WorkflowInputValidation represents validation rules for workflow inputs
+// WorkflowInputValidation represents validation rules for workflow inputs.
 type WorkflowInputValidation struct {
 	Enum []string `yaml:"enum,omitempty"` // List of allowed values
 	Min  *float64 `yaml:"min,omitempty"`  // Minimum value for numbers
 	Max  *float64 `yaml:"max,omitempty"`  // Maximum value for numbers
 }
 
-// WorkflowStep represents a single step in a workflow
+// WorkflowStep represents a single step in a workflow.
 type WorkflowStep struct {
-	ID           string                   `yaml:"id,omitempty"`           // Step identifier
-	If           string                   `yaml:"if,omitempty"`           // Conditional execution (CEL expression)
-	Run          string                   `yaml:"run,omitempty"`          // Command to run
-	Uses         string                   `yaml:"uses,omitempty"`         // Built-in step to use (e.g., "tako/checkout@v1")
-	With         map[string]interface{}   `yaml:"with,omitempty"`         // Parameters for built-in steps
-	Image        string                   `yaml:"image,omitempty"`        // Container image override
-	LongRunning  bool                     `yaml:"long_running,omitempty"` // Whether step runs asynchronously
-	Network      string                   `yaml:"network,omitempty"`      // Network access level
-	Capabilities []string                 `yaml:"capabilities,omitempty"` // Linux capabilities to grant
-	CacheKeyFiles string                  `yaml:"cache_key_files,omitempty"` // Glob pattern for cache key
-	Env          map[string]string        `yaml:"env,omitempty"`          // Environment variables
-	Produces     *WorkflowStepProduces    `yaml:"produces,omitempty"`     // Step outputs and events
-	OnFailure    []WorkflowStep           `yaml:"on_failure,omitempty"`   // Steps to run on failure
+	ID            string                 `yaml:"id,omitempty"`              // Step identifier
+	If            string                 `yaml:"if,omitempty"`              // Conditional execution (CEL expression)
+	Run           string                 `yaml:"run,omitempty"`             // Command to run
+	Uses          string                 `yaml:"uses,omitempty"`            // Built-in step to use (e.g., "tako/checkout@v1")
+	With          map[string]interface{} `yaml:"with,omitempty"`            // Parameters for built-in steps
+	Image         string                 `yaml:"image,omitempty"`           // Container image override
+	LongRunning   bool                   `yaml:"long_running,omitempty"`    // Whether step runs asynchronously
+	Network       string                 `yaml:"network,omitempty"`         // Network access level
+	Capabilities  []string               `yaml:"capabilities,omitempty"`    // Linux capabilities to grant
+	CacheKeyFiles string                 `yaml:"cache_key_files,omitempty"` // Glob pattern for cache key
+	Env           map[string]string      `yaml:"env,omitempty"`             // Environment variables
+	Produces      *WorkflowStepProduces  `yaml:"produces,omitempty"`        // Step outputs and events
+	OnFailure     []WorkflowStep         `yaml:"on_failure,omitempty"`      // Steps to run on failure
 }
 
 // WorkflowStepProduces represents what a step produces (outputs, artifacts, events)
 type WorkflowStepProduces struct {
-	Artifact string                   `yaml:"artifact,omitempty"` // Artifact name produced
-	Outputs  map[string]string        `yaml:"outputs,omitempty"`  // Output mappings
-	Events   []Event                  `yaml:"events,omitempty"`   // Events to emit
+	Artifact string            `yaml:"artifact,omitempty"` // Artifact name produced
+	Outputs  map[string]string `yaml:"outputs,omitempty"`  // Output mappings
+	Events   []Event           `yaml:"events,omitempty"`   // Events to emit
 }
 
 // UnmarshalYAML implements custom YAML unmarshaling for WorkflowStep to support backward compatibility
@@ -155,7 +155,7 @@ func validate(config *TakoConfig) error {
 		if err := ValidateSubscriptions(config.Subscriptions); err != nil {
 			return fmt.Errorf("invalid subscriptions: %w", err)
 		}
-		
+
 		// Validate that referenced workflows exist
 		for i, subscription := range config.Subscriptions {
 			if _, exists := config.Workflows[subscription.Workflow]; !exists {
@@ -215,7 +215,7 @@ func validateArtifacts(dependentArtifacts []string, definedArtifacts map[string]
 }
 
 // validateWorkflow validates a single workflow definition
-func validateWorkflow(name string, workflow *Workflow) error {
+func validateWorkflow(_ string, workflow *Workflow) error {
 	// Validate workflow inputs
 	for inputName, input := range workflow.Inputs {
 		if err := validateWorkflowInput(inputName, &input); err != nil {
@@ -234,7 +234,7 @@ func validateWorkflow(name string, workflow *Workflow) error {
 }
 
 // validateWorkflowInput validates a workflow input definition
-func validateWorkflowInput(name string, input *WorkflowInput) error {
+func validateWorkflowInput(_ string, input *WorkflowInput) error {
 	// Validate input type
 	if input.Type != "" {
 		validTypes := []string{"string", "boolean", "number"}
@@ -264,7 +264,7 @@ func validateWorkflowInput(name string, input *WorkflowInput) error {
 }
 
 // validateWorkflowStep validates a single workflow step
-func validateWorkflowStep(index int, step *WorkflowStep) error {
+func validateWorkflowStep(_ int, step *WorkflowStep) error {
 	// Either 'run' or 'uses' must be specified, but not both
 	if step.Run == "" && step.Uses == "" {
 		return fmt.Errorf("step must specify either 'run' or 'uses'")
@@ -304,7 +304,7 @@ func validateWorkflowStepProduces(produces *WorkflowStepProduces) error {
 		if outputValue == "" {
 			return fmt.Errorf("output '%s' cannot have empty value", outputName)
 		}
-		
+
 		// Validate known output formats
 		validFormats := []string{"from_stdout", "from_stderr", "from_file:", "from_env:"}
 		valid := false
@@ -330,9 +330,9 @@ func validateWorkflowStepProduces(produces *WorkflowStepProduces) error {
 	return nil
 }
 
-// Known built-in steps with their supported versions
+// knownBuiltinSteps defines the known built-in steps with their supported versions.
 var knownBuiltinSteps = map[string][]string{
-	"tako/checkout":             {"v1"},
+	"tako/checkout":            {"v1"},
 	"tako/fan-out":             {"v1"},
 	"tako/update-dependency":   {"v1"},
 	"tako/create-pull-request": {"v1"},
@@ -374,9 +374,10 @@ func validateCELExpression(expression string) error {
 	// Check for balanced parentheses
 	parenCount := 0
 	for _, char := range expression {
-		if char == '(' {
+		switch char {
+		case '(':
 			parenCount++
-		} else if char == ')' {
+		case ')':
 			parenCount--
 			if parenCount < 0 {
 				return fmt.Errorf("unbalanced parentheses in CEL expression: %s", expression)
@@ -408,9 +409,9 @@ func validateSemverRange(versionRange string) error {
 
 	// Patterns for semantic version ranges
 	patterns := []string{
-		`^\^\d+\.\d+\.\d+$`,                    // ^1.0.0
-		`^~\d+\.\d+\.\d+$`,                    // ~1.0.0
-		`^\d+\.\d+\.\d+$`,                     // 1.0.0
+		`^\^\d+\.\d+\.\d+$`,                         // ^1.0.0
+		`^~\d+\.\d+\.\d+$`,                          // ~1.0.0
+		`^\d+\.\d+\.\d+$`,                           // 1.0.0
 		`^\(\d+\.\d+\.\d+\.\.\.(\d+\.\d+\.\d+)?\]$`, // (1.0.0...2.0.0]
 		`^\[\d+\.\d+\.\d+\.\.\.(\d+\.\d+\.\d+)?\)$`, // [1.0.0...2.0.0)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -425,6 +425,68 @@ dependents: []
 `,
 			expectedError: "built-in step 'tako/checkout' must include version",
 		},
+		{
+			name: "unknown built-in step",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - uses: "tako/unknown@v1"
+dependents: []
+`,
+			expectedError: "unknown built-in step 'tako/unknown'",
+		},
+		{
+			name: "invalid CEL expression in subscription filter",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - "echo test"
+subscriptions:
+  - artifact: "org/repo:artifact"
+    events: ["test_event"]
+    filters: ["invalid((((expression"]
+    workflow: "test"
+`,
+			expectedError: "unbalanced parentheses in CEL expression",
+		},
+		{
+			name: "invalid template expression in event payload",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - id: "test"
+        run: "echo test"
+        produces:
+          events:
+            - type: "test_event"
+              payload:
+                version: "{{ .invalid"
+dependents: []
+`,
+			expectedError: "unbalanced template braces",
+		},
+		{
+			name: "invalid semver range in subscription",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - "echo test"
+subscriptions:
+  - artifact: "org/repo:artifact"
+    events: ["test_event"]
+    schema_version: "invalid.version.format"
+    workflow: "test"
+`,
+			expectedError: "invalid version range format",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -581,7 +581,7 @@ func TestLoad_WorkflowInputValidationErrors(t *testing.T) {
 			expectedError: "min/max validation is only supported for number inputs",
 		},
 		{
-			name: "max on non-number input", 
+			name: "max on non-number input",
 			inputYAML: `    inputs:
       my_input:
         type: boolean

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -233,7 +233,7 @@ subscriptions:
 	if len(config.Workflows) != 1 {
 		t.Errorf("expected 1 workflow, got %d", len(config.Workflows))
 	}
-	
+
 	releaseWorkflow := config.Workflows["release"]
 	if releaseWorkflow.On != "exec" {
 		t.Errorf("expected on 'exec', got %q", releaseWorkflow.On)
@@ -243,7 +243,7 @@ subscriptions:
 	if len(releaseWorkflow.Inputs) != 1 {
 		t.Errorf("expected 1 input, got %d", len(releaseWorkflow.Inputs))
 	}
-	
+
 	versionBumpInput := releaseWorkflow.Inputs["version-bump"]
 	if versionBumpInput.Type != "string" {
 		t.Errorf("expected input type 'string', got %q", versionBumpInput.Type)
@@ -277,7 +277,7 @@ subscriptions:
 	if len(config.Subscriptions) != 1 {
 		t.Errorf("expected 1 subscription, got %d", len(config.Subscriptions))
 	}
-	
+
 	subscription := config.Subscriptions[0]
 	if subscription.Artifact != "my-org/go-lib:go-lib" {
 		t.Errorf("expected artifact 'my-org/go-lib:go-lib', got %q", subscription.Artifact)
@@ -349,8 +349,8 @@ dependents: []
 
 func TestLoad_ValidationErrors(t *testing.T) {
 	testCases := []struct {
-		name         string
-		yamlContent  string
+		name          string
+		yamlContent   string
 		expectedError string
 	}{
 		{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -156,3 +156,298 @@ dependents: []
 		t.Errorf("expected workflow name to be 'my-workflow', got %q", config.Workflows["my-workflow"].Name)
 	}
 }
+
+func TestLoad_EventDrivenWorkflows(t *testing.T) {
+	yamlContent := `
+version: "0.1.0"
+artifacts:
+  go-lib:
+    path: "./go.mod"
+    ecosystem: "go"
+
+workflows:
+  release:
+    on: "exec"
+    inputs:
+      version-bump:
+        type: "string"
+        default: "patch"
+        validation:
+          enum: ["major", "minor", "patch"]
+    steps:
+      - id: "build"
+        run: "./scripts/build.sh --bump {{ .inputs.version-bump }}"
+        produces:
+          artifact: "go-lib"
+          outputs:
+            version: "from_stdout"
+          events:
+            - type: "library_built"
+              schema_version: "1.0.0"
+              payload:
+                version: "{{ .outputs.version }}"
+                commit_sha: "{{ .env.GITHUB_SHA }}"
+      - uses: "tako/fan-out@v1"
+        with:
+          event_type: "library_built"
+          wait_for_children: true
+
+subscriptions:
+  - artifact: "my-org/go-lib:go-lib"
+    events: ["library_built"]
+    schema_version: "^1.0.0"
+    filters:
+      - "semver.major(event.payload.version) > 0"
+    workflow: "release"
+    inputs:
+      upstream_version: "{{ .event.payload.version }}"
+`
+
+	tmpfile, err := os.CreateTemp(t.TempDir(), "tako.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(yamlContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := Load(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test artifacts
+	if len(config.Artifacts) != 1 {
+		t.Errorf("expected 1 artifact, got %d", len(config.Artifacts))
+	}
+	if config.Artifacts["go-lib"].Ecosystem != "go" {
+		t.Errorf("expected ecosystem 'go', got %q", config.Artifacts["go-lib"].Ecosystem)
+	}
+
+	// Test workflows
+	if len(config.Workflows) != 1 {
+		t.Errorf("expected 1 workflow, got %d", len(config.Workflows))
+	}
+	
+	releaseWorkflow := config.Workflows["release"]
+	if releaseWorkflow.On != "exec" {
+		t.Errorf("expected on 'exec', got %q", releaseWorkflow.On)
+	}
+
+	// Test inputs
+	if len(releaseWorkflow.Inputs) != 1 {
+		t.Errorf("expected 1 input, got %d", len(releaseWorkflow.Inputs))
+	}
+	
+	versionBumpInput := releaseWorkflow.Inputs["version-bump"]
+	if versionBumpInput.Type != "string" {
+		t.Errorf("expected input type 'string', got %q", versionBumpInput.Type)
+	}
+	if len(versionBumpInput.Validation.Enum) != 3 {
+		t.Errorf("expected 3 enum values, got %d", len(versionBumpInput.Validation.Enum))
+	}
+
+	// Test steps
+	if len(releaseWorkflow.Steps) != 2 {
+		t.Errorf("expected 2 steps, got %d", len(releaseWorkflow.Steps))
+	}
+
+	buildStep := releaseWorkflow.Steps[0]
+	if buildStep.ID != "build" {
+		t.Errorf("expected step ID 'build', got %q", buildStep.ID)
+	}
+	if buildStep.Produces == nil {
+		t.Fatal("expected produces section")
+	}
+	if len(buildStep.Produces.Events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(buildStep.Produces.Events))
+	}
+
+	fanOutStep := releaseWorkflow.Steps[1]
+	if fanOutStep.Uses != "tako/fan-out@v1" {
+		t.Errorf("expected uses 'tako/fan-out@v1', got %q", fanOutStep.Uses)
+	}
+
+	// Test subscriptions
+	if len(config.Subscriptions) != 1 {
+		t.Errorf("expected 1 subscription, got %d", len(config.Subscriptions))
+	}
+	
+	subscription := config.Subscriptions[0]
+	if subscription.Artifact != "my-org/go-lib:go-lib" {
+		t.Errorf("expected artifact 'my-org/go-lib:go-lib', got %q", subscription.Artifact)
+	}
+	if len(subscription.Events) != 1 || subscription.Events[0] != "library_built" {
+		t.Errorf("expected events ['library_built'], got %v", subscription.Events)
+	}
+}
+
+func TestLoad_MixedStepFormats(t *testing.T) {
+	yamlContent := `
+version: "0.1.0"
+workflows:
+  mixed-workflow:
+    steps:
+      - "echo simple step"
+      - id: "complex-step"
+        run: "echo complex step"
+        produces:
+          outputs:
+            result: "from_stdout"
+dependents: []
+`
+
+	tmpfile, err := os.CreateTemp(t.TempDir(), "tako.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(yamlContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := Load(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	workflow := config.Workflows["mixed-workflow"]
+	if len(workflow.Steps) != 2 {
+		t.Errorf("expected 2 steps, got %d", len(workflow.Steps))
+	}
+
+	// First step should be simple string
+	simpleStep := workflow.Steps[0]
+	if simpleStep.Run != "echo simple step" {
+		t.Errorf("expected run 'echo simple step', got %q", simpleStep.Run)
+	}
+	if simpleStep.ID != "" {
+		t.Errorf("expected empty ID for simple step, got %q", simpleStep.ID)
+	}
+
+	// Second step should be complex object
+	complexStep := workflow.Steps[1]
+	if complexStep.ID != "complex-step" {
+		t.Errorf("expected ID 'complex-step', got %q", complexStep.ID)
+	}
+	if complexStep.Run != "echo complex step" {
+		t.Errorf("expected run 'echo complex step', got %q", complexStep.Run)
+	}
+	if complexStep.Produces == nil || len(complexStep.Produces.Outputs) != 1 {
+		t.Error("expected produces section with 1 output")
+	}
+}
+
+func TestLoad_ValidationErrors(t *testing.T) {
+	testCases := []struct {
+		name         string
+		yamlContent  string
+		expectedError string
+	}{
+		{
+			name: "invalid event type",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - id: "test"
+        run: "echo test"
+        produces:
+          events:
+            - type: "invalid-event-type"
+dependents: []
+`,
+			expectedError: "event type 'invalid-event-type' must be snake_case",
+		},
+		{
+			name: "invalid subscription artifact format",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - "echo test"
+subscriptions:
+  - artifact: "invalid-format"
+    events: ["test_event"]
+    workflow: "test"
+`,
+			expectedError: "artifact reference 'invalid-format' must be in format 'repo:artifact'",
+		},
+		{
+			name: "subscription references non-existent workflow",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - "echo test"
+subscriptions:
+  - artifact: "org/repo:artifact"
+    events: ["test_event"]
+    workflow: "non_existent"
+`,
+			expectedError: "subscription 0 references non-existent workflow 'non_existent'",
+		},
+		{
+			name: "step with both run and uses",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - id: "invalid"
+        run: "echo test"
+        uses: "tako/checkout@v1"
+dependents: []
+`,
+			expectedError: "step cannot specify both 'run' and 'uses'",
+		},
+		{
+			name: "built-in step without version",
+			yamlContent: `
+version: "0.1.0"
+workflows:
+  test:
+    steps:
+      - uses: "tako/checkout"
+dependents: []
+`,
+			expectedError: "built-in step 'tako/checkout' must include version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpfile, err := os.CreateTemp(t.TempDir(), "tako.yml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			if _, err := tmpfile.Write([]byte(tc.yamlContent)); err != nil {
+				t.Fatal(err)
+			}
+			if err := tmpfile.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = Load(tmpfile.Name())
+			if err == nil {
+				t.Errorf("expected error, got nil")
+			} else if !strings.Contains(err.Error(), tc.expectedError) {
+				t.Errorf("expected error containing %q, got %q", tc.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/internal/config/events.go
+++ b/internal/config/events.go
@@ -23,7 +23,7 @@ func validateEventType(eventType string) error {
 	if eventType == "" {
 		return fmt.Errorf("event type cannot be empty")
 	}
-	
+
 	// Basic validation - only lowercase letters, numbers, and underscores
 	matched, err := regexp.MatchString("^[a-z][a-z0-9_]*$", eventType)
 	if err != nil {
@@ -32,7 +32,7 @@ func validateEventType(eventType string) error {
 	if !matched {
 		return fmt.Errorf("event type '%s' must be snake_case (lowercase letters, numbers, underscores only)", eventType)
 	}
-	
+
 	return nil
 }
 
@@ -41,7 +41,7 @@ func validateSchemaVersion(version string) error {
 	if version == "" {
 		return nil // Schema version is optional
 	}
-	
+
 	// Basic semantic version validation (x.y.z format)
 	matched, err := regexp.MatchString(`^\d+\.\d+\.\d+$`, version)
 	if err != nil {
@@ -50,7 +50,7 @@ func validateSchemaVersion(version string) error {
 	if !matched {
 		return fmt.Errorf("schema version '%s' must follow semantic versioning format (x.y.z)", version)
 	}
-	
+
 	return nil
 }
 
@@ -60,11 +60,11 @@ func (ep *EventProduction) ValidateEvents() error {
 		if err := validateEventType(event.Type); err != nil {
 			return fmt.Errorf("event %d: %w", i, err)
 		}
-		
+
 		if err := validateSchemaVersion(event.SchemaVersion); err != nil {
 			return fmt.Errorf("event %d (%s): %w", i, event.Type, err)
 		}
-		
+
 		// Validate template expressions in event payload
 		for payloadKey, payloadValue := range event.Payload {
 			if err := validateTemplateExpression(payloadValue); err != nil {
@@ -72,6 +72,7 @@ func (ep *EventProduction) ValidateEvents() error {
 			}
 		}
 	}
-	
+
 	return nil
 }
+

--- a/internal/config/events.go
+++ b/internal/config/events.go
@@ -64,6 +64,13 @@ func (ep *EventProduction) ValidateEvents() error {
 		if err := validateSchemaVersion(event.SchemaVersion); err != nil {
 			return fmt.Errorf("event %d (%s): %w", i, event.Type, err)
 		}
+		
+		// Validate template expressions in event payload
+		for payloadKey, payloadValue := range event.Payload {
+			if err := validateTemplateExpression(payloadValue); err != nil {
+				return fmt.Errorf("event %d (%s) payload '%s': %w", i, event.Type, payloadKey, err)
+			}
+		}
 	}
 	
 	return nil

--- a/internal/config/events.go
+++ b/internal/config/events.go
@@ -5,19 +5,19 @@ import (
 	"regexp"
 )
 
-// Event represents an event that can be emitted by a workflow step
+// Event represents an event that can be emitted by a workflow step.
 type Event struct {
 	Type          string            `yaml:"type"`
 	SchemaVersion string            `yaml:"schema_version,omitempty"`
 	Payload       map[string]string `yaml:"payload,omitempty"`
 }
 
-// EventProduction represents the events section in a produces block
+// EventProduction represents the events section in a produces block.
 type EventProduction struct {
 	Events []Event `yaml:"events,omitempty"`
 }
 
-// validateEventType validates that event types follow the naming conventions
+// validateEventType validates that event types follow the naming conventions.
 func validateEventType(eventType string) error {
 	// Event types should be snake_case and not empty
 	if eventType == "" {
@@ -36,7 +36,7 @@ func validateEventType(eventType string) error {
 	return nil
 }
 
-// validateSchemaVersion validates semantic version format if provided
+// validateSchemaVersion validates semantic version format if provided.
 func validateSchemaVersion(version string) error {
 	if version == "" {
 		return nil // Schema version is optional
@@ -54,7 +54,7 @@ func validateSchemaVersion(version string) error {
 	return nil
 }
 
-// ValidateEvents validates all events in an EventProduction
+// ValidateEvents validates all events in an EventProduction.
 func (ep *EventProduction) ValidateEvents() error {
 	for i, event := range ep.Events {
 		if err := validateEventType(event.Type); err != nil {
@@ -75,4 +75,3 @@ func (ep *EventProduction) ValidateEvents() error {
 
 	return nil
 }
-

--- a/internal/config/events.go
+++ b/internal/config/events.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Event represents an event that can be emitted by a workflow step
+type Event struct {
+	Type          string            `yaml:"type"`
+	SchemaVersion string            `yaml:"schema_version,omitempty"`
+	Payload       map[string]string `yaml:"payload,omitempty"`
+}
+
+// EventProduction represents the events section in a produces block
+type EventProduction struct {
+	Events []Event `yaml:"events,omitempty"`
+}
+
+// validateEventType validates that event types follow the naming conventions
+func validateEventType(eventType string) error {
+	// Event types should be snake_case and not empty
+	if eventType == "" {
+		return fmt.Errorf("event type cannot be empty")
+	}
+	
+	// Basic validation - only lowercase letters, numbers, and underscores
+	matched, err := regexp.MatchString("^[a-z][a-z0-9_]*$", eventType)
+	if err != nil {
+		return fmt.Errorf("error validating event type: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("event type '%s' must be snake_case (lowercase letters, numbers, underscores only)", eventType)
+	}
+	
+	return nil
+}
+
+// validateSchemaVersion validates semantic version format if provided
+func validateSchemaVersion(version string) error {
+	if version == "" {
+		return nil // Schema version is optional
+	}
+	
+	// Basic semantic version validation (x.y.z format)
+	matched, err := regexp.MatchString(`^\d+\.\d+\.\d+$`, version)
+	if err != nil {
+		return fmt.Errorf("error validating schema version: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("schema version '%s' must follow semantic versioning format (x.y.z)", version)
+	}
+	
+	return nil
+}
+
+// ValidateEvents validates all events in an EventProduction
+func (ep *EventProduction) ValidateEvents() error {
+	for i, event := range ep.Events {
+		if err := validateEventType(event.Type); err != nil {
+			return fmt.Errorf("event %d: %w", i, err)
+		}
+		
+		if err := validateSchemaVersion(event.SchemaVersion); err != nil {
+			return fmt.Errorf("event %d (%s): %w", i, event.Type, err)
+		}
+	}
+	
+	return nil
+}

--- a/internal/config/events_test.go
+++ b/internal/config/events_test.go
@@ -120,3 +120,4 @@ func TestEventProduction_ValidateEvents(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/config/events_test.go
+++ b/internal/config/events_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestValidateEventType(t *testing.T) {
+	testCases := []struct {
+		name        string
+		eventType   string
+		expectError bool
+	}{
+		{"valid snake_case", "library_built", false},
+		{"valid single word", "built", false},
+		{"valid with numbers", "version_1_released", false},
+		{"empty string", "", true},
+		{"starts with number", "1_event", true},
+		{"contains hyphens", "library-built", true},
+		{"contains uppercase", "Library_Built", true},
+		{"contains spaces", "library built", true},
+		{"contains special chars", "library_built!", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEventType(tc.eventType)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error for event type %q, got nil", tc.eventType)
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error for event type %q: %v", tc.eventType, err)
+			}
+		})
+	}
+}
+
+func TestValidateSchemaVersion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		version     string
+		expectError bool
+	}{
+		{"valid semantic version", "1.2.3", false},
+		{"empty string (optional)", "", false},
+		{"major version", "2.0.0", false},
+		{"patch version", "1.0.1", false},
+		{"invalid format missing patch", "1.2", true},
+		{"invalid format extra segment", "1.2.3.4", true},
+		{"invalid format with text", "v1.2.3", true},
+		{"invalid format with hyphens", "1.2.3-alpha", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSchemaVersion(tc.version)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error for schema version %q, got nil", tc.version)
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error for schema version %q: %v", tc.version, err)
+			}
+		})
+	}
+}
+
+func TestEventProduction_ValidateEvents(t *testing.T) {
+	testCases := []struct {
+		name        string
+		events      []Event
+		expectError bool
+	}{
+		{
+			name: "valid events",
+			events: []Event{
+				{Type: "library_built", SchemaVersion: "1.0.0"},
+				{Type: "test_completed", SchemaVersion: "2.1.0"},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid event without schema version",
+			events: []Event{
+				{Type: "simple_event"},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid event type",
+			events: []Event{
+				{Type: "invalid-type", SchemaVersion: "1.0.0"},
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid schema version",
+			events: []Event{
+				{Type: "valid_event", SchemaVersion: "invalid"},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty event type",
+			events: []Event{
+				{Type: "", SchemaVersion: "1.0.0"},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := &EventProduction{Events: tc.events}
+			err := ep.ValidateEvents()
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/events_test.go
+++ b/internal/config/events_test.go
@@ -120,4 +120,3 @@ func TestEventProduction_ValidateEvents(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/config/subscription.go
+++ b/internal/config/subscription.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Subscription represents a repository's subscription to events from other repositories
+type Subscription struct {
+	Artifact      string            `yaml:"artifact"`       // Format: repo:artifact (e.g., "my-org/go-lib:go-lib")
+	Events        []string          `yaml:"events"`         // List of event types to subscribe to
+	SchemaVersion string            `yaml:"schema_version,omitempty"` // Compatible schema version range
+	Filters       []string          `yaml:"filters,omitempty"`        // CEL expressions for event filtering
+	Workflow      string            `yaml:"workflow"`       // Workflow to trigger
+	Inputs        map[string]string `yaml:"inputs,omitempty"` // Input mappings for the triggered workflow
+}
+
+// validateArtifactReference validates the repo:artifact format
+func validateArtifactReference(artifact string) error {
+	if artifact == "" {
+		return fmt.Errorf("artifact reference cannot be empty")
+	}
+	
+	// Expected format: owner/repo:artifact
+	parts := strings.Split(artifact, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("artifact reference '%s' must be in format 'repo:artifact'", artifact)
+	}
+	
+	repo := parts[0]
+	artifactName := parts[1]
+	
+	// Validate repository format (owner/repo)
+	repoParts := strings.Split(repo, "/")
+	if len(repoParts) != 2 {
+		return fmt.Errorf("repository '%s' must be in format 'owner/repo'", repo)
+	}
+	
+	if repoParts[0] == "" || repoParts[1] == "" {
+		return fmt.Errorf("repository '%s' has empty owner or repo name", repo)
+	}
+	
+	// Validate artifact name (basic validation)
+	if artifactName == "" {
+		return fmt.Errorf("artifact name cannot be empty in reference '%s'", artifact)
+	}
+	
+	// Artifact names should follow basic naming conventions
+	matched, err := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9_-]*$", artifactName)
+	if err != nil {
+		return fmt.Errorf("error validating artifact name: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("artifact name '%s' must start with a letter and contain only letters, numbers, underscores, and hyphens", artifactName)
+	}
+	
+	return nil
+}
+
+// validateSchemaVersionRange validates semantic version range format if provided
+func validateSchemaVersionRange(version string) error {
+	if version == "" {
+		return nil // Schema version is optional
+	}
+	
+	// Support different version range formats:
+	// - "1.2.3" (exact version)
+	// - "^1.2.3" (compatible with 1.x.x)
+	// - "~1.2.3" (compatible with 1.2.x)
+	// - "(1.1.0...2.0.0]" (range notation)
+	
+	// Basic validation - check for common patterns
+	patterns := []string{
+		`^\d+\.\d+\.\d+$`,                    // exact: 1.2.3
+		`^\^\d+\.\d+\.\d+$`,                  // caret: ^1.2.3
+		`^~\d+\.\d+\.\d+$`,                   // tilde: ~1.2.3
+		`^\(\d+\.\d+\.\d+\.\.\.\d+\.\d+\.\d+\]$`, // range: (1.1.0...2.0.0]
+	}
+	
+	for _, pattern := range patterns {
+		matched, err := regexp.MatchString(pattern, version)
+		if err != nil {
+			return fmt.Errorf("error validating schema version range: %w", err)
+		}
+		if matched {
+			return nil // Valid format found
+		}
+	}
+	
+	return fmt.Errorf("schema version range '%s' must be in format: 'x.y.z', '^x.y.z', '~x.y.z', or '(x.y.z...x.y.z]'", version)
+}
+
+// ValidateSubscription validates a single subscription
+func (s *Subscription) ValidateSubscription() error {
+	// Validate artifact reference
+	if err := validateArtifactReference(s.Artifact); err != nil {
+		return fmt.Errorf("invalid artifact reference: %w", err)
+	}
+	
+	// Validate events list
+	if len(s.Events) == 0 {
+		return fmt.Errorf("events list cannot be empty")
+	}
+	
+	for i, event := range s.Events {
+		if err := validateEventType(event); err != nil {
+			return fmt.Errorf("event %d: %w", i, err)
+		}
+	}
+	
+	// Validate schema version range
+	if err := validateSchemaVersionRange(s.SchemaVersion); err != nil {
+		return fmt.Errorf("invalid schema version: %w", err)
+	}
+	
+	// Validate workflow name
+	if s.Workflow == "" {
+		return fmt.Errorf("workflow name cannot be empty")
+	}
+	
+	// Basic workflow name validation
+	matched, err := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9_-]*$", s.Workflow)
+	if err != nil {
+		return fmt.Errorf("error validating workflow name: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("workflow name '%s' must start with a letter and contain only letters, numbers, underscores, and hyphens", s.Workflow)
+	}
+	
+	return nil
+}
+
+// ValidateSubscriptions validates a list of subscriptions
+func ValidateSubscriptions(subscriptions []Subscription) error {
+	for i, subscription := range subscriptions {
+		if err := subscription.ValidateSubscription(); err != nil {
+			return fmt.Errorf("subscription %d: %w", i, err)
+		}
+	}
+	
+	return nil
+}

--- a/internal/config/subscription.go
+++ b/internal/config/subscription.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Subscription represents a repository's subscription to events from other repositories
+// Subscription represents a repository's subscription to events from other repositories.
 type Subscription struct {
 	Artifact      string            `yaml:"artifact"`                 // Format: repo:artifact (e.g., "my-org/go-lib:go-lib")
 	Events        []string          `yaml:"events"`                   // List of event types to subscribe to
@@ -16,7 +16,7 @@ type Subscription struct {
 	Inputs        map[string]string `yaml:"inputs,omitempty"`         // Input mappings for the triggered workflow
 }
 
-// validateArtifactReference validates the repo:artifact format
+// validateArtifactReference validates the repo:artifact format.
 func validateArtifactReference(artifact string) error {
 	if artifact == "" {
 		return fmt.Errorf("artifact reference cannot be empty")
@@ -58,7 +58,7 @@ func validateArtifactReference(artifact string) error {
 	return nil
 }
 
-// ValidateSubscription validates a single subscription
+// ValidateSubscription validates a single subscription.
 func (s *Subscription) ValidateSubscription() error {
 	// Validate artifact reference
 	if err := validateArtifactReference(s.Artifact); err != nil {
@@ -112,7 +112,7 @@ func (s *Subscription) ValidateSubscription() error {
 	return nil
 }
 
-// ValidateSubscriptions validates a list of subscriptions
+// ValidateSubscriptions validates a list of subscriptions.
 func ValidateSubscriptions(subscriptions []Subscription) error {
 	for i, subscription := range subscriptions {
 		if err := subscription.ValidateSubscription(); err != nil {
@@ -122,4 +122,3 @@ func ValidateSubscriptions(subscriptions []Subscription) error {
 
 	return nil
 }
-

--- a/internal/config/subscription.go
+++ b/internal/config/subscription.go
@@ -8,12 +8,12 @@ import (
 
 // Subscription represents a repository's subscription to events from other repositories
 type Subscription struct {
-	Artifact      string            `yaml:"artifact"`       // Format: repo:artifact (e.g., "my-org/go-lib:go-lib")
-	Events        []string          `yaml:"events"`         // List of event types to subscribe to
+	Artifact      string            `yaml:"artifact"`                 // Format: repo:artifact (e.g., "my-org/go-lib:go-lib")
+	Events        []string          `yaml:"events"`                   // List of event types to subscribe to
 	SchemaVersion string            `yaml:"schema_version,omitempty"` // Compatible schema version range
 	Filters       []string          `yaml:"filters,omitempty"`        // CEL expressions for event filtering
-	Workflow      string            `yaml:"workflow"`       // Workflow to trigger
-	Inputs        map[string]string `yaml:"inputs,omitempty"` // Input mappings for the triggered workflow
+	Workflow      string            `yaml:"workflow"`                 // Workflow to trigger
+	Inputs        map[string]string `yaml:"inputs,omitempty"`         // Input mappings for the triggered workflow
 }
 
 // validateArtifactReference validates the repo:artifact format
@@ -21,31 +21,31 @@ func validateArtifactReference(artifact string) error {
 	if artifact == "" {
 		return fmt.Errorf("artifact reference cannot be empty")
 	}
-	
+
 	// Expected format: owner/repo:artifact
 	parts := strings.Split(artifact, ":")
 	if len(parts) != 2 {
 		return fmt.Errorf("artifact reference '%s' must be in format 'repo:artifact'", artifact)
 	}
-	
+
 	repo := parts[0]
 	artifactName := parts[1]
-	
+
 	// Validate repository format (owner/repo)
 	repoParts := strings.Split(repo, "/")
 	if len(repoParts) != 2 {
 		return fmt.Errorf("repository '%s' must be in format 'owner/repo'", repo)
 	}
-	
+
 	if repoParts[0] == "" || repoParts[1] == "" {
 		return fmt.Errorf("repository '%s' has empty owner or repo name", repo)
 	}
-	
+
 	// Validate artifact name (basic validation)
 	if artifactName == "" {
 		return fmt.Errorf("artifact name cannot be empty in reference '%s'", artifact)
 	}
-	
+
 	// Artifact names should follow basic naming conventions
 	matched, err := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9_-]*$", artifactName)
 	if err != nil {
@@ -54,10 +54,9 @@ func validateArtifactReference(artifact string) error {
 	if !matched {
 		return fmt.Errorf("artifact name '%s' must start with a letter and contain only letters, numbers, underscores, and hyphens", artifactName)
 	}
-	
+
 	return nil
 }
-
 
 // ValidateSubscription validates a single subscription
 func (s *Subscription) ValidateSubscription() error {
@@ -65,35 +64,35 @@ func (s *Subscription) ValidateSubscription() error {
 	if err := validateArtifactReference(s.Artifact); err != nil {
 		return fmt.Errorf("invalid artifact reference: %w", err)
 	}
-	
+
 	// Validate events list
 	if len(s.Events) == 0 {
 		return fmt.Errorf("events list cannot be empty")
 	}
-	
+
 	for i, event := range s.Events {
 		if err := validateEventType(event); err != nil {
 			return fmt.Errorf("event %d: %w", i, err)
 		}
 	}
-	
+
 	// Validate schema version range using improved validation
 	if err := validateSemverRange(s.SchemaVersion); err != nil {
 		return fmt.Errorf("invalid schema version: %w", err)
 	}
-	
+
 	// Validate CEL filters
 	for i, filter := range s.Filters {
 		if err := validateCELExpression(filter); err != nil {
 			return fmt.Errorf("filter %d: %w", i, err)
 		}
 	}
-	
+
 	// Validate workflow name
 	if s.Workflow == "" {
 		return fmt.Errorf("workflow name cannot be empty")
 	}
-	
+
 	// Basic workflow name validation
 	matched, err := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9_-]*$", s.Workflow)
 	if err != nil {
@@ -102,14 +101,14 @@ func (s *Subscription) ValidateSubscription() error {
 	if !matched {
 		return fmt.Errorf("workflow name '%s' must start with a letter and contain only letters, numbers, underscores, and hyphens", s.Workflow)
 	}
-	
+
 	// Validate template expressions in input mappings
 	for inputName, inputValue := range s.Inputs {
 		if err := validateTemplateExpression(inputValue); err != nil {
 			return fmt.Errorf("input '%s': %w", inputName, err)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -120,6 +119,7 @@ func ValidateSubscriptions(subscriptions []Subscription) error {
 			return fmt.Errorf("subscription %d: %w", i, err)
 		}
 	}
-	
+
 	return nil
 }
+

--- a/internal/config/subscription_test.go
+++ b/internal/config/subscription_test.go
@@ -222,4 +222,3 @@ func TestValidateSubscriptions(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/config/subscription_test.go
+++ b/internal/config/subscription_test.go
@@ -222,3 +222,4 @@ func TestValidateSubscriptions(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/config/subscription_test.go
+++ b/internal/config/subscription_test.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestValidateArtifactReference(t *testing.T) {
+	testCases := []struct {
+		name        string
+		artifact    string
+		expectError bool
+	}{
+		{"valid reference", "my-org/go-lib:go-lib", false},
+		{"valid with hyphens", "my-org/client-app:main-service", false},
+		{"valid with underscores", "my_org/go_lib:go_lib", false},
+		{"empty string", "", true},
+		{"missing colon", "my-org/go-lib", true},
+		{"multiple colons", "my-org/go-lib:artifact:extra", true},
+		{"empty repo", ":artifact", true},
+		{"empty artifact", "my-org/go-lib:", true},
+		{"invalid repo format", "my-org:go-lib", true},
+		{"missing repo name", "my-org/:artifact", true},
+		{"missing owner", "/go-lib:artifact", true},
+		{"artifact starts with number", "my-org/go-lib:1artifact", true},
+		{"artifact with spaces", "my-org/go-lib:my artifact", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateArtifactReference(tc.artifact)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error for artifact %q, got nil", tc.artifact)
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error for artifact %q: %v", tc.artifact, err)
+			}
+		})
+	}
+}
+
+func TestValidateSchemaVersionRange(t *testing.T) {
+	testCases := []struct {
+		name        string
+		version     string
+		expectError bool
+	}{
+		{"exact version", "1.2.3", false},
+		{"caret range", "^1.2.3", false},
+		{"tilde range", "~1.2.3", false},
+		{"parenthesis range", "(1.1.0...2.0.0]", false},
+		{"empty string (optional)", "", false},
+		{"invalid format", "invalid", true},
+		{"missing patch in exact", "1.2", true},
+		{"invalid caret", "^1.2", true},
+		{"invalid tilde", "~1.2", true},
+		{"malformed range", "[1.1.0...2.0.0)", true},
+		{"incomplete range", "(1.1.0...", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSchemaVersionRange(tc.version)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error for version range %q, got nil", tc.version)
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error for version range %q: %v", tc.version, err)
+			}
+		})
+	}
+}
+
+func TestSubscription_ValidateSubscription(t *testing.T) {
+	testCases := []struct {
+		name         string
+		subscription Subscription
+		expectError  bool
+	}{
+		{
+			name: "valid subscription",
+			subscription: Subscription{
+				Artifact:      "my-org/go-lib:go-lib",
+				Events:        []string{"library_built"},
+				SchemaVersion: "^1.0.0",
+				Workflow:      "update_integration",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid subscription without schema version",
+			subscription: Subscription{
+				Artifact: "my-org/go-lib:go-lib",
+				Events:   []string{"library_built", "test_completed"},
+				Workflow: "update_integration",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid artifact reference",
+			subscription: Subscription{
+				Artifact: "invalid-format",
+				Events:   []string{"library_built"},
+				Workflow: "update_integration",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty events list",
+			subscription: Subscription{
+				Artifact: "my-org/go-lib:go-lib",
+				Events:   []string{},
+				Workflow: "update_integration",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid event type",
+			subscription: Subscription{
+				Artifact: "my-org/go-lib:go-lib",
+				Events:   []string{"invalid-event"},
+				Workflow: "update_integration",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid schema version",
+			subscription: Subscription{
+				Artifact:      "my-org/go-lib:go-lib",
+				Events:        []string{"library_built"},
+				SchemaVersion: "invalid",
+				Workflow:      "update_integration",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty workflow name",
+			subscription: Subscription{
+				Artifact: "my-org/go-lib:go-lib",
+				Events:   []string{"library_built"},
+				Workflow: "",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid workflow name",
+			subscription: Subscription{
+				Artifact: "my-org/go-lib:go-lib",
+				Events:   []string{"library_built"},
+				Workflow: "1invalid",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.subscription.ValidateSubscription()
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSubscriptions(t *testing.T) {
+	testCases := []struct {
+		name          string
+		subscriptions []Subscription
+		expectError   bool
+	}{
+		{
+			name: "valid subscriptions",
+			subscriptions: []Subscription{
+				{
+					Artifact: "my-org/go-lib:go-lib",
+					Events:   []string{"library_built"},
+					Workflow: "update_integration",
+				},
+				{
+					Artifact: "my-org/other-lib:other-lib",
+					Events:   []string{"other_event"},
+					Workflow: "other_workflow",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "empty subscriptions list",
+			subscriptions: []Subscription{},
+			expectError:   false,
+		},
+		{
+			name: "one invalid subscription",
+			subscriptions: []Subscription{
+				{
+					Artifact: "my-org/go-lib:go-lib",
+					Events:   []string{"library_built"},
+					Workflow: "update_integration",
+				},
+				{
+					Artifact: "invalid-format",
+					Events:   []string{"other_event"},
+					Workflow: "other_workflow",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSubscriptions(tc.subscriptions)
+			if tc.expectError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/subscription_test.go
+++ b/internal/config/subscription_test.go
@@ -53,13 +53,13 @@ func TestValidateSchemaVersionRange(t *testing.T) {
 		{"missing patch in exact", "1.2", true},
 		{"invalid caret", "^1.2", true},
 		{"invalid tilde", "~1.2", true},
-		{"malformed range", "[1.1.0...2.0.0)", true},
+		{"malformed range", "[1.1.0...2.0.0)", false},
 		{"incomplete range", "(1.1.0...", true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateSchemaVersionRange(tc.version)
+			err := validateSemverRange(tc.version)
 			if tc.expectError && err == nil {
 				t.Errorf("expected error for version range %q, got nil", tc.version)
 			}


### PR DESCRIPTION
## Summary

Updated testing instructions for #117: 

• **Enhanced validation pipeline** with CEL expression validation for subscription filters
• **Built-in step validation** against known steps (tako/checkout@v1, tako/fan-out@v1, etc.)
• **Template expression validation** for event payloads with balanced braces checking
• **Semantic version range validation** supporting ^1.0.0, ~1.0.0, and (1.0.0...2.0.0] formats
• **Comprehensive schema completeness** with proper WorkflowInput validation constraints
• **Backward compatibility** maintaining legacy dependents model while adding modern subscriptions
• **Extensive test coverage** following the testing plan requirements
• **Full E2E test compatibility** ensuring all existing functionality works correctly

## Test plan

**Automated tests:**
- Unit tests: `go test -v ./...`
- Short unit tests: `go test -v -test.short ./...`
- Local E2E tests: `go test -v -tags=e2e --local ./...`
- Remote E2E tests: `go test -v -tags=e2e --remote ./...`
- CI simulation: `act --container-architecture linux/amd64 -P ubuntu-latest=catthehacker/ubuntu:act-latest`

**Manual testing (all steps verified and working):**

First, install the required commands:
```bash
go install ./cmd/tako
go install ./cmd/takotest
```

Then run the following tests:

```bash
# Create test directory
mkdir manual-test && cd manual-test

# Test 1: Event-driven workflow validation
cat > tako.yml << 'EOL'
version: "0.1.0"
artifacts:
  go-lib:
    path: "./go.mod"
    ecosystem: "go"
workflows:
  release:
    on: "exec"
    inputs:
      version-bump:
        type: "string"
        default: "patch"
        validation:
          enum: ["major", "minor", "patch"]
    steps:
      - id: "build"
        run: "./scripts/build.sh --bump {{ .inputs.version-bump }}"
        produces:
          artifact: "go-lib"
          outputs:
            version: "from_stdout"
          events:
            - type: "library_built"
              schema_version: "1.0.0"
              payload:
                version: "{{ .outputs.version }}"
                commit_sha: "{{ .env.GITHUB_SHA }}"
      - uses: "tako/fan-out@v1"
        with:
          event_type: "library_built"
          wait_for_children: true
subscriptions:
  - artifact: "my-org/go-lib:go-lib"
    events: ["library_built"]
    schema_version: "^1.0.0"
    filters:
      - "semver.major(event.payload.version) > 0"
    workflow: "release"
    inputs:
      upstream_version: "{{ .event.payload.version }}"
EOL

# Should validate successfully
tako validate
# Expected output: "Validation successful\!"

# Test 2: Invalid event type validation
cat > tako.yml << 'EOL'
version: "0.1.0"
workflows:
  test:
    steps:
      - id: "test"
        run: "echo test"
        produces:
          events:
            - type: "invalid-event-type"
dependents: []
EOL

# Should fail with validation error about snake_case
tako validate
# Expected error: "event type 'invalid-event-type' must be snake_case"

# Test 3: Unknown built-in step validation
cat > tako.yml << 'EOL'
version: "0.1.0"
workflows:
  test:
    steps:
      - uses: "tako/unknown@v1"
dependents: []
EOL

# Should fail with unknown built-in step error
tako validate
# Expected error: "unknown built-in step 'tako/unknown'"

# Test 4: Invalid CEL filter validation
cat > tako.yml << 'EOL'
version: "0.1.0"
workflows:
  test:
    steps:
      - "echo test"
subscriptions:
  - artifact: "org/repo:artifact"
    events: ["test_event"]
    filters: ["invalid((((expression"]
    workflow: "test"
EOL

# Should fail with CEL expression error
tako validate
# Expected error: "unbalanced parentheses in CEL expression"

# Test 5: Invalid template expression validation
cat > tako.yml << 'EOL'
version: "0.1.0"
workflows:
  test:
    steps:
      - id: "test"
        run: "echo test"
        produces:
          events:
            - type: "test_event"
              payload:
                version: "{{ .invalid"
dependents: []
EOL

# Should fail with unbalanced template braces error
tako validate
# Expected error: "unbalanced template braces in expression"

# Test 6: WorkflowInput validation constraints
cat > tako.yml << 'EOL'
version: "0.1.0"
workflows:
  test:
    inputs:
      my_input:
        type: number
        validation:
          enum: ["1", "2"]
    steps:
      - "echo hello"
dependents: []
EOL

# Should fail with enum validation error for number inputs
tako validate
# Expected error: "enum validation is only supported for string inputs"

# Test 7: Invalid semver range validation
cat > tako.yml << 'EOL'
version: "0.1.0"
workflows:
  test:
    steps:
      - "echo test"
subscriptions:
  - artifact: "org/repo:artifact"
    events: ["test_event"]
    schema_version: "invalid.version.format"
    workflow: "test"
EOL

# Should fail with version range format error
tako validate
# Expected error: "invalid version range format 'invalid.version.format'. Supported formats: ^1.0.0, ~1.0.0, 1.0.0, (1.0.0...2.0.0], [1.0.0...2.0.0)"

# Cleanup
cd .. && rm -rf manual-test
```

**Edge cases tested:**
- Mixed step formats (string and object)
- Backward compatibility with legacy dependents
- Empty validation scenarios
- Complex subscription filter expressions
- Template expressions in various contexts
- Built-in step version validation
- Schema version range patterns

**Error scenarios verified:**
- Invalid event type formats
- Malformed artifact references
- Unknown built-in steps
- Unbalanced CEL expressions
- Template brace mismatches
- Input validation constraint violations
- Version range format errors

Fixes #99