### PR TITLE
feat: add gofmt pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,17 @@ Tako differentiates itself from existing tools by focusing on **dependency-aware
 *   **vs. Git Submodules/Scripts:** This is the manual, error-prone approach that Tako aims to replace with a structured, repeatable process.
 *   **vs. GitHub Actions:** A CI/CD platform for automation *after* code is pushed. Tako is a developer tool for the local machine, designed to ensure code is correct *before* it's pushed. Additionally, Tako can be used for automation like GHA, allowing its configuration to be reusable for multiple purposes.
 
-## 2. Core Concepts
+## 2. Getting Started
+
+### Developer Setup
+
+To ensure consistent code formatting, this project uses a `gofmt` pre-commit hook. To install the hooks, run the following command from the root of the repository:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+## 3. Core Concepts
 
 ### 2.1. Workspace & Repository Management
 *   **Workspace Root:** A "workspace" is not a formal concept with a global configuration file. For any given `tako` command, the **workspace root is the repository from which the command is executed**.

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Installs the git hooks from the scripts/ directory.
+
+# This script creates a symbolic link from the project's .git/hooks/ directory
+# to the scripts/ directory. This allows the hooks to be version-controlled.
+
+HOOKS_DIR=$(git rev-parse --git-dir)/hooks
+SCRIPTS_DIR=$(git rev-parse --show-toplevel)/scripts
+
+# Create a symbolic link for the pre-commit hook
+ln -sfv "$SCRIPTS_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
+
+echo "Git hooks installed successfully."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# A hook script to format Go code before committing.
+#
+# This script runs gofmt on all staged .go files.
+# If gofmt makes changes, the changes are added to the commit.
+
+# Get the list of staged .go files
+GO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+
+if [ -z "$GO_FILES" ]; then
+    exit 0
+fi
+
+# Format the staged .go files
+echo "Running gofmt on staged files..."
+gofmt -w $GO_FILES
+
+# Add the formatted files back to the staging area
+git add $GO_FILES
+
+exit 0


### PR DESCRIPTION
This change introduces a pre-commit hook to automatically format Go code using `gofmt` before each commit.

It includes:
- A `scripts/pre-commit` file that runs `gofmt` on staged `.go` files.
- An `install-hooks.sh` script to simplify the installation of the hook.
- Updated `README.md` with instructions for setting up the pre-commit hook.

This ensures that all Go code in the repository maintains a consistent format.

Fixes: #123